### PR TITLE
ZeroDivisionError bug fix w/ estimated records in DataSource

### DIFF
--- a/dashboard/models/data_source.py
+++ b/dashboard/models/data_source.py
@@ -2,7 +2,15 @@ from django.db import models
 from django.utils import timezone
 from .source_type import SourceType
 from django.core.urlresolvers import reverse
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
 
+def validate_nonzero(value):
+    if value == 0:
+        raise ValidationError(
+            _('Quantity {} is not allowed'.format(value)),
+            params={'value': value},
+        )
 
 class DataSource(models.Model):
 	STATE_CHOICES = (
@@ -19,7 +27,8 @@ class DataSource(models.Model):
 
 	title = models.CharField(max_length=50)
 	url = models.CharField(max_length=150, blank=True)
-	estimated_records = models.PositiveIntegerField(default=0)
+	estimated_records = models.PositiveIntegerField(default=47,
+  												validators=[validate_nonzero])
 	type = models.ForeignKey(SourceType, on_delete=models.CASCADE)
 	state = models.CharField(max_length=2,
 							choices=STATE_CHOICES,


### PR DESCRIPTION
this was fixed in Zach's initial extraction script branch, but it never made it to `dev`, so I've added it here. We can't have zero estimated records if we want to know what percent of estimated records are uploaded or registered. I've taken the liberty to add the default value of 47 because it is the most common random number. In other words, 47 appears to be the quintessential random number of the universe. 