### PR TITLE
Fix dashboard cards

### DIFF
--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -11,19 +11,19 @@
       <div class="card text-center bg-light">
           <div class="card-body">
             <h3 class="card-title text-muted">Sources</h3>
-            <div class="card-text font-weight-bold display-4">{{ source_count | intword}} </div>
+            <div class="card-text font-weight-bold display-4">{{ datasource_count | intword}} </div>
           </div>
       </div>
       <div class="card text-center bg-light">
           <div class="card-body">
             <h3 class="card-title text-muted">Groups</h3>
-            <div class="card-text font-weight-bold display-4">{{ group_count | intword}} </div>
+            <div class="card-text font-weight-bold display-4">{{ datagroup_count | intword}} </div>
           </div>
       </div>
       <div class="card text-center bg-light">
           <div class="card-body">
               <h3 class="card-title text-muted">Documents</h3>
-              <div class="card-text font-weight-bold display-4">{{ document_count | intword}} </div>
+              <div class="card-text font-weight-bold display-4">{{ datadocument_count | intword}} </div>
           </div>
 
       </div>


### PR DESCRIPTION
The `index.html` template was using different variable names than what `views\dashboard/py` was preparing.