### PR TITLE
change form logic on render

### DIFF
--- a/dashboard/views/data_group.py
+++ b/dashboard/views/data_group.py
@@ -195,7 +195,7 @@ def data_group_detail(request, pk,
     docs_page = paginator.page(page)
 
     inc_upload = all([d.matched for d in docs])
-    include_extract = any([d.matched
+    include_extract = all([d.matched
                             for d in docs]) and not all([d.extracted
                                                             for d in docs])
     return render(request, template_name,{


### PR DESCRIPTION
the fix here will isolate the rendering of the upload PDF form in the page until ALL pdfs are uploaded, once that is true, then the extracted text upload form will show up.