### PR TITLE
Fix post-save and post-cancel redirect

### DIFF
--- a/dashboard/tests/functional_tests.py
+++ b/dashboard/tests/functional_tests.py
@@ -240,6 +240,8 @@ class TestDataSourceAndDataGroup(StaticLiveServerTestCase):
         save_button.click()
         # Saving the product should return the browser to the list of documents without products
         self.assertIn("link_product_list", self.browser.current_url)
+        # The URL of the link_product_list page should be keyed to the DataGroup, not DataSource
+        self.assertEqual(self.live_server_url + '/link_product_list/' + str(dgpk), self.browser.current_url)
 
         #check at the model level to confirm that the edits have been applied
         # self.assertEqual(dd_pk, 'x')

--- a/dashboard/views/product_curation.py
+++ b/dashboard/views/product_curation.py
@@ -109,7 +109,7 @@ def link_product_form(request, pk, template_name=('product_curation/'
                                                  updated_at=timezone.now())
             p = ProductDocument(product=product, document=doc)
             p.save()
-        return redirect('link_product_list', pk=data_source_id)
+        return redirect('link_product_list', pk=doc.data_group.pk)
     return render(request, template_name,{'document': doc, 'form': form})
 
 @login_required()

--- a/templates/product_curation/link_product_form.html
+++ b/templates/product_curation/link_product_form.html
@@ -12,7 +12,7 @@ Link {{ document }} to Product</h1>
     {% csrf_token %}
     {% include 'core/bs4_form.html' with form=form %}
     <button type="submit" class="btn btn-primary">Save</button>
-    <a class="btn btn-secondary" href="{% url 'link_product_list' document.data_group.data_source_id %}">Cancel</a>
+    <a class="btn btn-secondary" href="{% url 'link_product_list' document.data_group.id %}">Cancel</a>
     <a class="btn btn-info btn-secondary" role="button" title="details"
      href="/media/{{ document.data_group.dgurl }}/pdf/{{ document.filename }}" target = "_blank">
     <span class="oi"></span>Open PDF</a>


### PR DESCRIPTION
The post-save and post-cancel redirect from the product linking page `http://127.0.0.1:8000/link_product_form/<pk>` were using the old DataSource id instead of the DataGroup id. This has been corrected