### PR TITLE
add inputs to link_product_form view and test

### DIFF
--- a/dashboard/models/product.py
+++ b/dashboard/models/product.py
@@ -8,15 +8,21 @@ from django.core.urlresolvers import reverse
 
 
 class Product(models.Model):
-	prod_cat = models.ForeignKey(ProductCategory, related_name='category', on_delete=models.CASCADE, null=True, blank=True)
-	data_source = models.ForeignKey(DataSource, related_name='source', on_delete=models.CASCADE)
+	prod_cat = models.ForeignKey(ProductCategory, related_name='category',
+							on_delete=models.CASCADE, null=True, blank=True)
+	data_source = models.ForeignKey(DataSource, related_name='source',
+							on_delete=models.CASCADE)
 	documents = models.ManyToManyField(DataDocument, through='ProductDocument')
-	source_category = models.ForeignKey(SourceCategory, on_delete=models.CASCADE, null=True, blank=True)
+	source_category = models.ForeignKey(SourceCategory,
+							on_delete=models.CASCADE, null=True, blank=True)
 	title = models.CharField(max_length=255)
-	manufacturer = models.CharField(db_index=True, max_length=250, null=True, blank=True, default = '')
-	upc = models.CharField(db_index=True, max_length=60, null=False, blank=False, unique=True)
+	manufacturer = models.CharField(db_index=True, max_length=250,
+							null=True, blank=True, default = '')
+	upc = models.CharField(db_index=True, max_length=60, null=False,
+							blank=False, unique=True)
 	url = models.CharField(max_length=500, null=True, blank=True)
-	brand_name = models.CharField(db_index=True, max_length=200, null=True, blank=True, default = '')
+	brand_name = models.CharField(db_index=True, max_length=200, null=True,
+							blank=True, default = '')
 	size = models.CharField(max_length=100, null=True, blank=True)
 	model_number = models.CharField(max_length=200, null=True, blank=True)
 	color = models.CharField(max_length=100, null=True, blank=True)
@@ -29,7 +35,8 @@ class Product(models.Model):
 	large_image = models.CharField(max_length=500, null=True, blank=True)
 	created_at = models.DateTimeField(default=timezone.now)
 	updated_at = models.DateTimeField(null=True, blank=True)
-	puc_assigned_usr = models.ForeignKey('auth.User', on_delete=models.SET_NULL, null=True, blank = True)
+	puc_assigned_usr = models.ForeignKey('auth.User',
+							on_delete=models.SET_NULL, null=True, blank = True)
 	puc_assigned_script = models.ForeignKey('Script', on_delete=models.SET_NULL, null=True, blank = True)
 	puc_assigned_time = models.DateTimeField(null=True, blank=True)
 

--- a/dashboard/tests/functional_tests_rollback.py
+++ b/dashboard/tests/functional_tests_rollback.py
@@ -60,7 +60,7 @@ class RollbackStaticLiveServerTestCase(StaticLiveServerTestCase):
     the efficient rollback approach of TestCase. TransactionTestCase loads the \
     fixtures with every test method and destroys the test database after each one.\
     The following methods override this slow behavior in favor of TestCase's \
-    rollback approach. 
+    rollback approach.
     """
     @classmethod
     def setUpClass(cls):
@@ -113,7 +113,7 @@ class RollbackStaticLiveServerTestCase(StaticLiveServerTestCase):
 class FunctionalTests(RollbackStaticLiveServerTestCase):
     fixtures = ['00_superuser.yaml', '01_lookups.yaml',
     '02_datasource.yaml' , '03_datagroup.yaml', '04_productcategory.yaml',
-    '05_product.yaml', '06_datadocument.yaml' , '07_script.yaml', 
+    '05_product.yaml', '06_datadocument.yaml' , '07_script.yaml',
      '08_extractedtext.yaml','09_productdocument.yaml']
 
     @classmethod
@@ -129,7 +129,7 @@ class FunctionalTests(RollbackStaticLiveServerTestCase):
         if settings.TEST_BROWSER == 'firefox':
             self.browser = webdriver.Firefox()
         else:
-            self.browser = webdriver.Chrome() 
+            self.browser = webdriver.Chrome()
         self.test_start = time.time()
         log_karyn_in(self)
 
@@ -205,7 +205,7 @@ class FunctionalTests(RollbackStaticLiveServerTestCase):
                                         downloaded_at=timezone.now(),
                                         download_script=None,
                                         csv=SimpleUploadedFile('walmart_msds_3.csv', source_csv.read()))
-        
+
 
     #def test_edit_persistence(self):
     #    print("DataGroup objects in test_edit_persistence: {}".format(DataGroup.objects.count()))
@@ -312,7 +312,8 @@ class FunctionalTests(RollbackStaticLiveServerTestCase):
         self.browser.get(self.live_server_url + '/link_product_list/' + str(dgpk))
         create_prod_link = self.browser.find_element_by_xpath('//*[@id="products"]/tbody/tr[1]/td[2]/a')
         create_prod_link.click()
-
+        upc = self.browser.find_element_by_name('upc')
+        self.assertIn('stub_', upc.get_attribute('value'), 'Default value of upc input should be the stub_xx value.')
         title_input = self.browser.find_element_by_xpath('//*[@id="id_title"]')
         manufacturer_input = self.browser.find_element_by_xpath('//*[@id="id_manufacturer"]')
         brand_name_input = self.browser.find_element_by_xpath('//*[@id="id_brand_name"]')
@@ -545,24 +546,24 @@ class FunctionalTests(RollbackStaticLiveServerTestCase):
         self.browser.get('%s%s' % (self.live_server_url, '/qa'))
         script_qa_link = self.browser.find_element_by_xpath(
             '//*[@id="extraction_script_table"]/tbody/tr[contains(.,"Sun INDS (extract)")]/td[4]/a'
-        )    
+        )
         self.assertEqual(script_qa_link.text, 'Continue QA',
                          'The QA button should now say "Continue QA" instead of "Begin QA"')
-        
+
         ### Testing the QA Group and Extracted Text-level views
         #
         # go to the QA Group page
         # find the row that contains the Sun INDS link, click the fourth td
         script_qa_link = self.browser.find_element_by_xpath(
             '//*[@id="extraction_script_table"]/tbody/tr[contains(.,"Sun INDS (extract)")]/td[4]/a'
-        ) 
-        dd_test = DataDocument.objects.filter(title__startswith="Alba Hawaiian Coconut Milk Body Cream")[0] 
+        )
+        dd_test = DataDocument.objects.filter(title__startswith="Alba Hawaiian Coconut Milk Body Cream")[0]
         pk_test = dd_test.id
         script_qa_link.click()
         # confirm that the QA Group index page has opened
         self.assertIn("/qa/extractionscript" , self.browser.current_url, \
             "The opened page should include the qa/extractionscript route")
-        # 
+        #
         # The record with the test_pk ID is no longer going to appear in this page,
         # because it has been set to qa_checked = True
         # pick an arbitrary first record instead
@@ -585,7 +586,7 @@ class FunctionalTests(RollbackStaticLiveServerTestCase):
         # TODO: add seed records that allow testing the Skip button
         btn_skip = self.browser.find_element_by_xpath('/html/body/div[1]/div[2]/div/a[3]')
 
-        # clicking the exit button should return the browser to the 
+        # clicking the exit button should return the browser to the
         # QA Group page
         btn_exit = self.browser.find_element_by_xpath('/html/body/div[1]/div[2]/div/a[4]')
         btn_exit.click()
@@ -601,7 +602,7 @@ class TestExtractedText(StaticLiveServerTestCase):
         if settings.TEST_BROWSER == 'firefox':
             self.browser = webdriver.Firefox()
         else:
-            self.browser = webdriver.Chrome() 
+            self.browser = webdriver.Chrome()
         log_karyn_in(self)
 
     def tearDown(self):
@@ -635,6 +636,3 @@ def wait_for_element(self, elm, by='id', timeout=10):
     wait = WebDriverWait(self.browser, timeout)
     wait.until(EC.presence_of_element_located((By.XPATH, elm)))
     return self.browser.find_element_by_xpath(elm)
-
-
-

--- a/dashboard/views/product_curation.py
+++ b/dashboard/views/product_curation.py
@@ -109,7 +109,7 @@ def link_product_form(request, pk, template_name=('product_curation/'
                                                  updated_at=now)
             p = ProductDocument(product=product, document=doc)
             p.save()
-        return redirect('link_product_list', pk=doc.data_group.pk)
+            return redirect('link_product_list', pk=doc.data_group.pk)
     return render(request, template_name,{'document': doc, 'form': form})
 
 @login_required()


### PR DESCRIPTION
this adds 3 new input boxes to the view. the test asserts that the default `stub_xx` value loads into the page. However we may want to isolate the creation/linking of products <-> documents, we are currently searching for a product with the same title first and assigning that if it exists.