### PR TITLE
update certifi and django reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-certifi==2016.2.28
-Django>=1.11.5
+certifi
+Django>=1.11.5,<2.0
 pytz==2017.2
 PyYAML==3.12
 wincertstore==0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ django-queryset-csv>=1.0.0
 docutils>=0.12
 elasticsearch-dsl>=2.0.0,<3.0.0
 elasticsearch>=2.0.0,<3.0.0
-django-bootstrap-datepicker>=1.2.3
+django-bootstrap-datepicker==1.2.4
 selenium>=3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ docutils>=0.12
 elasticsearch-dsl>=2.0.0,<3.0.0
 elasticsearch>=2.0.0,<3.0.0
 django-bootstrap-datepicker>=1.2.3
+selenium>=3.11.0


### PR DESCRIPTION
we need to specify not to grab V2 of django and w/ the `certifi` package we just want to have the most current version, I got this error when I was trying to install when we required a specific version of `certifi`

`Cannot uninstall 'certifi'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.`

`certifi==2016.2.28`