### PR TITLE
Issue 231

### DIFF
--- a/dashboard/tests/test_datagroup_detail.py
+++ b/dashboard/tests/test_datagroup_detail.py
@@ -94,7 +94,6 @@ class DataGroupTest(TestCase):
     def test_bulk_create_post(self):
         '''test the POST to create Products and link if needed'''
         doc = DataDocument.objects.create(data_group=self.objects.dg)
-        print(self.objects.dg.datadocument_set.get_queryset())
         response = self.client.get(f'/datagroup/{self.objects.dg.pk}')
         self.assertEqual(response.context['bulk'], 1,
                 'Not all DataDocuments linked to Product, bulk_create needed')
@@ -102,6 +101,11 @@ class DataGroupTest(TestCase):
                                                                 {'bulk':47})
         self.assertEqual(response.context['bulk'], 0,
                 'Product linked to all DataDocuments, no bulk_create needed.')
+        product = ProductDocument.objects.get(document=doc).product
+        self.assertEqual(product.title, 'unknown',
+                                        'Title should be unkown in bulk_create')
+        self.assertEqual(product.upc, 'stub_2',
+                                    'UPC should be created for second Product')
 
 
 # <!-- request.POST -->

--- a/dashboard/views/data_group.py
+++ b/dashboard/views/data_group.py
@@ -21,7 +21,8 @@ from djqscsv import *
 
 from dashboard.models import (DataGroup, DataDocument, Script, ExtractedText,
                             ExtractedChemical, WeightFractionType,
-                            UnitType, ExtractedFunctionalUse, DocumentType)
+                            UnitType, ExtractedFunctionalUse, DocumentType,
+                            ProductDocument)
 
 
 class DataGroupForm(forms.ModelForm):
@@ -92,7 +93,8 @@ def data_group_detail(request, pk,
                       template_name='data_group/datagroup_detail.html'):
     datagroup = get_object_or_404(DataGroup, pk=pk, )
     dg_type = str(datagroup.group_type) # 'MSDS' #FunctionalUse
-    docs = DataDocument.objects.filter(data_group_id=pk)
+    docs = datagroup.datadocument_set.get_queryset()
+    prod_link = ProductDocument.objects.filter(document__in=docs)
     npage = 50 # TODO: make this dynamic someday in its own ticket
     page = request.GET.get('page')
     paginator = Paginator(docs, npage)
@@ -111,6 +113,7 @@ def data_group_detail(request, pk,
                   'ext_err'           : {},
                   'upload_form'       : not datagroup.all_matched(),
                   'extract_form'      : include_extract_form(datagroup, dg_type),
+                  'bulk_form'         : len(docs) != len(prod_link),
                   'msg'               : ''
                   }
     if request.method == 'POST' and 'upload' in request.POST:
@@ -201,6 +204,8 @@ def data_group_detail(request, pk,
                                                     'uploaded successfully.')
                 context['extract_form'] = include_extract_form(datagroup,
                                                                         dg_type)
+    if request.method == 'POST' and 'bulk' in request.POST:
+        print('yay')
     return render(request, template_name, context)
 
 

--- a/dashboard/views/product_curation.py
+++ b/dashboard/views/product_curation.py
@@ -96,7 +96,7 @@ def link_product_form(request, pk, template_name=('product_curation/'
             brand_name = form['brand_name'].value()
             manufacturer = form['manufacturer'].value()
             upc_stub = form['upc'].value()
-            try:
+            try: # could use the get_or_create method here
                 product = Product.objects.get(title=title)
             except Product.DoesNotExist:
                 now = timezone.now()

--- a/templates/data_group/datagroup_detail.html
+++ b/templates/data_group/datagroup_detail.html
@@ -70,9 +70,8 @@
               {% if datagroup.matched_docs == 0 %}disabled{% endif %}>
           <span class="oi oi-data-transfer-download"></span> Download All PDF Documents
         </button>
-
+        <br><br>
         {% if extract_form %}
-            <br><br>
             <a class="btn btn-secondary" data-toggle="collapse" id="btn_extract_text_form" href="#extract_form">
               <span class="oi oi-data-transfer-upload"></span>&nbsp;Upload Extracted Text
             </a>
@@ -107,7 +106,6 @@
         {% endif %}
 
         {% if upload_form %}
-            <br><br>
             <a class="btn btn-secondary" data-toggle="collapse" href="#upload_form">
                 <span class="oi oi-data-transfer-upload"></span>&nbsp;Upload Data Group PDFs
             </a>
@@ -121,6 +119,13 @@
                     <input type="submit" class="btn btn-primary" name="upload" value="Submit">
                 </form>
             </div>
+        {% endif %}
+        {% if not upload_form and not extract_form and bulk_form %}
+        <form class="" method="post">
+          {% csrf_token %}
+          <input type="submit" class="btn btn-primary" name="bulk" value="Bulk Create Products">
+        </form>
+
         {% endif %}
 
 

--- a/templates/data_group/datagroup_detail.html
+++ b/templates/data_group/datagroup_detail.html
@@ -120,10 +120,10 @@
                 </form>
             </div>
         {% endif %}
-        {% if not upload_form and not extract_form and bulk_form %}
+        {% if not upload_form and not extract_form and bulk %}
         <form class="" method="post">
           {% csrf_token %}
-          <input type="submit" class="btn btn-primary" name="bulk" value="Bulk Create Products">
+          <input type="submit" class="btn btn-primary" name="bulk" value="Bulk Create {{ bulk }} Products">
         </form>
 
         {% endif %}


### PR DESCRIPTION
the batch create button will go away like the other upload/extract buttons do in this solution. Best to start w/ DataGroup 6 for this as it is the smallest and you can use the `test_composition_DG_6.csv` to make all docs extracted w/ little work.