### PR TITLE
fix namespaces so all tests run, fix test_extracted_text_qa_notes test

### DIFF
--- a/dashboard/models/extracted_text.py
+++ b/dashboard/models/extracted_text.py
@@ -38,7 +38,7 @@ class ExtractedText(CommonInfo):
         return nextid
 
     def clean(self):
-        print('cleaning ExtractedText object in the model')
+        # print('cleaning ExtractedText object in the model')
         if self.doc_date:
             if len(self.doc_date) != 10:
                 raise ValidationError("Date format is the wrong length.")

--- a/dashboard/models/qa_notes.py
+++ b/dashboard/models/qa_notes.py
@@ -15,8 +15,8 @@ class QANotes(CommonInfo):
 
     def clean(self):
 
-        print('------inside the QANotes model clean')
-        print(self.extracted_text.qa_edited)
+        # print('------inside the QANotes model clean')
+        # print(self.extracted_text.qa_edited)
 
         if self.extracted_text.qa_edited and self.qa_notes is None:
             raise ValidationError(_('qa_notes needs to be populated if you edited the data'))

--- a/dashboard/tests/__init__.py
+++ b/dashboard/tests/__init__.py
@@ -2,12 +2,12 @@
 #from .test_models import *
 #from .functional_tests_rollback import *
 
-from .test_product_to_puc import *
-from .test_product_to_attribute import *
-from .test_extracted_text import *
-from .test_models import *
-from .test_root_url_no_login import *
-from .test_datagroup_detail import *
-from .test_dashboard import *
-from .test_qa import *
-from .test_extracted_qa import *
+from .test_product_to_puc import * #1
+from .test_product_to_attribute import * #1
+from .test_extracted_text import * #2
+from .test_models import * #6
+from .test_root_url_no_login import * #2
+from .test_datagroup_detail import * #5
+from .test_dashboard import * #4
+from .test_qa import * #1
+from .nav_bar import * #5

--- a/dashboard/tests/test_extracted_text.py
+++ b/dashboard/tests/test_extracted_text.py
@@ -4,9 +4,9 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 
 from .loader import load_model_objects
-from dashboard.models import ExtractedText
+from dashboard.models import ExtractedText, QANotes
 
-class ModelsTest(TestCase):
+class ExtractedTest(TestCase):
 
     def setUp(self):
 
@@ -43,32 +43,7 @@ class ModelsTest(TestCase):
             self.fail("clean() raised ExceptionType unexpectedly!")
 
     def test_extracted_text_qa_notes(self):
-        text = ExtractedText(doc_date= '2018-04-13',
-                                            data_document=self.doc,
-                                            extraction_script=self.script)
-        text.qa_status = ExtractedText.APPROVED_WITH_ERROR
-        with self.assertRaises(ValidationError):
-            text.clean()
-        text.qa_notes = "Some notes belong here if qa_status is APPROVED_WITH_ERROR"
-        self.assertRaises(ValidationError, text.clean)
-
-    def test_validation_errors_appear_in_qa_template(self):
-        extext = ExtractedText(doc_date= '2018-04-13',
-                                            data_document=self.doc,
-                                            extraction_script=self.script)
-        chem_formset = ChemFormSet(instance=extext, prefix='chemicals')
-        context = {
-            'extracted_text': extext,
-            'doc': self.doc, 
-            'script': self.script, 
-            'chem_formset': chem_formset, 
-            'stats': stats, 
-            'nextid': nextid,
-            'chem_formset': chem_formset,
-            'notesform': notesform,
-            }
-        response = self.client.post('/lists/new', data={'item_text': ''})
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'home.html')
-        expected_error = "You can't have an empty list item"
-        self.assertContains(response, expected_error)
+        self.objects.extext.qa_edited = True
+        note = QANotes.objects.create(extracted_text=self.objects.extext)
+        self.assertEqual(note.qa_notes, None)
+        self.assertRaises(ValidationError, note.clean)

--- a/dashboard/tests/test_product_to_puc.py
+++ b/dashboard/tests/test_product_to_puc.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from .loader import load_model_objects
 from dashboard.models import ProductToPUC
 
-class ModelsTest(TestCase):
+class UberPUCTest(TestCase):
 
     def setUp(self):
         self.objects = load_model_objects()


### PR DESCRIPTION
I fixed the qa_notes test that matt had added but wasn't being run, so the fail never showed and changed the class names so that all tests will be run, we should currently have 27 tests at this point.