### PR TITLE
Exclude DSSToxSubstance and ExtractedChemical from the search results

### DIFF
--- a/dashboard/tests/__init__.py
+++ b/dashboard/tests/__init__.py
@@ -13,3 +13,4 @@ from .test_qa import * #1
 from .nav_bar import * #5
 from .test_extracted_functionaluse import * #1
 from .test_chem_search import * #1
+from .test_faceted_search import *

--- a/dashboard/tests/test_faceted_search.py
+++ b/dashboard/tests/test_faceted_search.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+from django.test.client import Client
+from django.urls import resolve
+from django.contrib.auth.models import User
+
+class FacetedSearchTest(TestCase):
+    fixtures = ['00_superuser.yaml', '01_lookups.yaml',
+                '02_datasource.yaml', '03_datagroup.yaml', '04_PUC.yaml',
+                '05_product.yaml', '06_datadocument.yaml', '07_script.yaml',
+                '08_extractedtext.yaml', '09_productdocument.yaml', '10_extractedchemical', '11_dsstoxsubstance']
+    def setUp(self):
+        self.c = Client()
+
+    def test_faceted_search_excludes_chemicals(self):
+        response = self.c.get('/find/?q=ethyl')
+        self.assertContains(response, 'Data Document')
+        self.assertNotContains(response, 'Extracted Chemical')
+        self.assertNotContains(response, 'DSSTox Substance')

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -64,6 +64,8 @@ urlpatterns = [
     url(r'^p_json/', views.product_ajax, 	name='p_ajax_url'),
 	url(r'^chem_search/', views.chem_search, name='chem_search'),
 	url(r'^dl_pucs/', views.download_PUCs, name='download_PUCs'),
+    url(r'^dsstox_substance/(?P<pk>\d+)$', views.dsstox_substance_detail,
+                                        name='dsstox_substance'),
     #url(r'^search/', FacetedSearchView(form_class=FacetedSearchForm, facet_fields=['brand_name','prod_cat']), name='haystack_search'),
     # test with: /puc-autocomplete/?q=Art
 ]

--- a/dashboard/views/__init__.py
+++ b/dashboard/views/__init__.py
@@ -9,3 +9,4 @@ from .ajax import *
 from .search_forms import *
 from .search import *
 from .chem_search import *
+from .dsstox_substance import *

--- a/dashboard/views/dsstox_substance.py
+++ b/dashboard/views/dsstox_substance.py
@@ -1,0 +1,17 @@
+from django import forms
+from django.conf import settings
+from django.core.files import File
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render, redirect, get_object_or_404
+
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+
+from dashboard.models import (DSSToxSubstance)
+
+@login_required()
+def dsstox_substance_detail(request, pk,
+                      template_name='chemicals/dsstox_substance_detail.html'):
+    s = get_object_or_404(DSSToxSubstance, pk=pk, )
+    return render(request, template_name, {'substance': s,  })

--- a/dashboard/views/search_forms.py
+++ b/dashboard/views/search_forms.py
@@ -11,6 +11,8 @@ class FacetedProductSearchForm(FacetedSearchForm):
 
   def search(self):
     sqs = super(FacetedProductSearchForm, self).search()
+    # The SearchQuerySet should only return Products and Data
+    sqs = sqs.exclude(facet_model_name='DSSTox Substance').exclude(facet_model_name='Extracted Chemical')
     if self.pucs:
         query = None
     for puc in self.pucs:

--- a/dashboard/views/search_forms.py
+++ b/dashboard/views/search_forms.py
@@ -11,8 +11,8 @@ class FacetedProductSearchForm(FacetedSearchForm):
 
   def search(self):
     sqs = super(FacetedProductSearchForm, self).search()
-    # The SearchQuerySet should only return Products and Data
-    sqs = sqs.exclude(facet_model_name='DSSTox Substance').exclude(facet_model_name='Extracted Chemical')
+    # The SearchQuerySet should only return Products and Data Documents
+    sqs = sqs.filter(facet_model_name__in=['Data Document' ,'Product'])
     if self.pucs:
         query = None
     for puc in self.pucs:

--- a/templates/chemicals/dsstox_substance_detail.html
+++ b/templates/chemicals/dsstox_substance_detail.html
@@ -1,0 +1,10 @@
+{% extends 'core/base.html' %}
+{% load staticfiles %}
+{% load humanize %}
+
+{% block content %}
+    <h1 class="col-sm-12">
+        <span name="title">{{ substance }}</span>
+    </h1>
+
+{% endblock %}


### PR DESCRIPTION
The `/find` page now explicitly filters on results whose `facet_model_name` is either "Data Document" or "Product". 

I also added a few new files: before I excluded those models from the search results page, it was throwing errors related to the lack of a view to handle the URLs for DSSTox Substance objects.