### PR TITLE
move bulk button, add product column w/ link

### DIFF
--- a/dashboard/tests/functional/test_datagroup_detail.py
+++ b/dashboard/tests/functional/test_datagroup_detail.py
@@ -135,3 +135,15 @@ class DataGroupTest(TestCase):
         span = '<span class="oi oi-circle-check" style="color:green;"></span>'
         self.assertIn(span, response,
                       'Check should be present if matched.')
+
+    def test_detail_table_headers(self):
+        pk = self.objects.dg.pk
+        response = self.client.get(f'/datagroup/{pk}').content.decode('utf8')
+        self.assertIn('<th>Product</th>', response,
+                      'Data Group should have Product column.')
+        fu = GroupType.objects.create(title='Functional use')
+        self.objects.dg.group_type = fu
+        self.objects.dg.save()
+        response = self.client.get(f'/datagroup/{pk}').content.decode('utf8')
+        self.assertNotIn('<th>Product</th>', response,
+                      'Data Group should have Product column.')

--- a/dashboard/views/data_group.py
+++ b/dashboard/views/data_group.py
@@ -112,7 +112,8 @@ def data_group_detail(request, pk,
                   'extract_form'      : include_extract_form(datagroup, dg_type),
                   'bulk'              : len(docs) - len(prod_link),
                   'msg'               : '',
-                  'hnp'               : dg_type == 'Habits and practices'
+                  'hnp'               : dg_type == 'Habits and practices',
+                  'composition'       : dg_type == 'Composition',
                   }
     if request.method == 'POST' and 'upload' in request.POST:
         print(request.FILES)

--- a/dashboard/views/product_curation.py
+++ b/dashboard/views/product_curation.py
@@ -9,7 +9,9 @@ from django.forms import ModelForm, ModelChoiceField
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.decorators import login_required
 
-from dashboard.models import DataSource, DataGroup, DataDocument, DocumentType, Product, ProductDocument, PUC, ProductToPUC
+from dashboard.models import *
+from dashboard.forms import ProductPUCForm
+
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 class ProductLinkForm(ModelForm):

--- a/dashboard/views/product_curation.py
+++ b/dashboard/views/product_curation.py
@@ -113,8 +113,7 @@ def link_product_form(request, pk, template_name=('product_curation/'
                 product.size = form['size'].value()
                 product.color = form['color'].value()
                 product.save()
-            if not ProductDocument.objects.filter(product=product,
-                                                    document=doc).exists():
+            if not ProductDocument.objects.filter(document=doc).exists():
                 p = ProductDocument(product=product, document=doc)
                 p.save()
             document_type = form['document_type'].value()

--- a/dashboard/views/product_curation.py
+++ b/dashboard/views/product_curation.py
@@ -113,8 +113,10 @@ def link_product_form(request, pk, template_name=('product_curation/'
                 product.size = form['size'].value()
                 product.color = form['color'].value()
                 product.save()
-            p = ProductDocument(product=product, document=doc)
-            p.save()
+            if not ProductDocument.objects.filter(product=product,
+                                                    document=doc).exists():
+                p = ProductDocument(product=product, document=doc)
+                p.save()
             document_type = form['document_type'].value()
             if document_type != doc.document_type:
                 doc.document_type = DocumentType.objects.get(pk=document_type)

--- a/templates/data_group/datagroup_detail.html
+++ b/templates/data_group/datagroup_detail.html
@@ -121,24 +121,27 @@
                 </form>
             </div>
         {% endif %}
-        {% if not upload_form and not extract_form and bulk and not hnp %}
-        <form class="" method="post">
-          {% csrf_token %}
-          <input type="submit" class="btn btn-primary" name="bulk" value="Bulk Create {{ bulk }} Products">
-        </form>
 
-        {% endif %}
 
 
     {% if documents %}
     <br>
     <br>
     <h4>{{ datagroup.registered_docs }} documents registered, {{ datagroup.matched_docs }} matched, {{  datagroup.extracted_docs }} extracted</h4>
-    <p>
-      <a class="btn btn-secondary" href="docs_csv/{{ datagroup.id }}">
-        <span class="oi oi-spreadsheet"></span>
-        &nbsp;Export all records in {{ datagroup.name }} to csv</a>
-    </p>
+    <div class="inline-block">
+      {% if bulk and not upload_form %}
+      <form class="float-right" method="post">
+        {% csrf_token %}
+        <input type="submit" class="btn btn-primary" name="bulk" value="Bulk Create {{ bulk }} Products">
+      </form>
+      {% endif %}
+      <p>
+        <a class="btn btn-secondary" href="docs_csv/{{ datagroup.id }}">
+          <span class="oi oi-spreadsheet"></span>
+          &nbsp;Export all records in {{ datagroup.name }} to csv</a>
+      </p>
+    </div>
+
         </div>
       <table class="table table-striped table-bordered dataTable no-footer table-sm" id="docs">
         <thead class="table-primary">
@@ -148,6 +151,9 @@
         <th>Edit</th>
         {% else %}
         <th>Extracted</th>
+        {% endif %}
+        {% if composition %}
+        <th>Product</th>
         {% endif %}
 
         </thead>
@@ -187,6 +193,20 @@
             </span>
           {% endif %}
             </td>
+
+          {% if composition %}
+          <td align="center">
+            {% if doc.products.exists %}
+            <a class="btn btn-info btn-sm" role="button" title="Go to Product Detail"
+             href='{% url 'product_detail' doc.products.first.pk %}'>{{doc.products.first}}</a>
+              <p style="display:none;">{{ doc.products.exists }}</p>
+            {% else %}
+            <span class="oi oi-circle-x" style="color:red;">
+              <p style="display:none;">{{ doc.products.exists }}</p>
+          </td>
+            {% endif %}
+          {% endif %}
+
           </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
currently the button that is in the 'Product' column will be filled with the title of the product, which if bulk-created will end up being 'unknown' for potentially many of the rows in this table. Probably not a big deal, but worth mentioning.