### PR TITLE
321: Add data_document__data_group__group_type as search facet

### DIFF
--- a/dashboard/models/data_document.py
+++ b/dashboard/models/data_document.py
@@ -37,6 +37,7 @@ class DataDocument(CommonInfo):
             title=self.title,
             filename=self.filename,
             url=self.url,
+            group_type=self.data_group.group_type.title ,
             facet_model_name='Data Document',
         )
         obj.save()

--- a/dashboard/search_indexes.py
+++ b/dashboard/search_indexes.py
@@ -85,13 +85,6 @@ class ProductIndex(indexes.SearchIndex, indexes.Indexable):
         return [puc.pk for puc in obj.puc_set.all()]
         #return obj.puc_set.all().values_list('pk', flat=True)
 
-
-# The document type can't be properly indexed until it's added here:
-# https://github.com/HumanExposure/factotum/issues/125   
-#    document_type = indexes.CharField(
-#        model_attr='document_type',
-#        faceted=True)
-
     def get_model(self):
         return Product
 
@@ -111,6 +104,7 @@ class DataDocumentIndex(indexes.SearchIndex, indexes.Indexable):
     template_name='search/indexes/dashboard/data_document_text.txt')
     title            = indexes.EdgeNgramField(model_attr='title')
     facet_model_name = indexes.CharField(faceted=True)
+    group_type       = indexes.CharField(faceted=True, model_attr='data_group__group_type')
     uploaded_at      = indexes.DateTimeField(model_attr='uploaded_at')
     result_css_class = indexes.CharField()
     
@@ -121,13 +115,6 @@ class DataDocumentIndex(indexes.SearchIndex, indexes.Indexable):
     
     def prepare_result_css_class(self, obj):
         return "datadocument-result"
-
-
-# The document type can't be properly indexed until it's added here:
-# https://github.com/HumanExposure/factotum/issues/125   
-#    document_type = indexes.CharField(
-#        model_attr='document_type',
-#        faceted=True)
 
     def get_model(self):
         return DataDocument

--- a/dashboard/tests/functional/test_faceted_search.py
+++ b/dashboard/tests/functional/test_faceted_search.py
@@ -18,6 +18,16 @@ class FacetedSearchTest(TestCase):
         self.assertContains(response, 'Data Document')
         self.assertNotContains(response, 'Extracted Chemical')
         self.assertNotContains(response, 'DSSTox Substance')
+    
+    def test_group_type_facet(self):
+        response = self.c.get('/find/?q=diatom')
+        self.assertContains(response, 'Filter by Group Type')
+        
+        response = self.c.get('/find/?q=diatom&group_type=Unidentified')
+        self.assertContains(response, 'Showing 1 - 20 of')
+
+        response = self.c.get('/find/?q=diatom&group_type=BadGroupName')
+        self.assertContains(response, 'Sorry, no result found')
 
 
 

--- a/dashboard/views/search.py
+++ b/dashboard/views/search.py
@@ -23,7 +23,7 @@ def bulk_indexing():
 
 class FacetedSearchView(BaseFacetedSearchView):
     form_class = FacetedProductSearchForm
-    facet_fields = ['prod_cat', 'brand_name', 'facet_model_name']
+    facet_fields = ['prod_cat', 'brand_name', 'facet_model_name','group_type']
     template_name = 'search/facet_search.html'
     paginate_by = 20
     context_object_name = 'object_list'

--- a/dashboard/views/search_forms.py
+++ b/dashboard/views/search_forms.py
@@ -4,7 +4,6 @@ class FacetedProductSearchForm(FacetedSearchForm):
   def __init__(self, *args, **kwargs):
     data = dict(kwargs.get("data", []))
     self.pucs = data.get('pucs', [])
-    print('self.pucs %s' % data)
     self.brands = data.get('brand_name', [])
     self.models = data.get('facet_model_name',[])
     self.group_types = data.get('group_type',[])
@@ -14,7 +13,7 @@ class FacetedProductSearchForm(FacetedSearchForm):
     sqs = super(FacetedProductSearchForm, self).search()
     # The SearchQuerySet should only return Products and Data Documents
     sqs = sqs.filter(facet_model_name__in=['Data Document' ,'Product'])
-    print(sqs.facet_counts())
+    #print(sqs.facet_counts())
     if self.pucs:
         query = None
         for puc in self.pucs:

--- a/dashboard/views/search_forms.py
+++ b/dashboard/views/search_forms.py
@@ -7,12 +7,14 @@ class FacetedProductSearchForm(FacetedSearchForm):
     print('self.pucs %s' % data)
     self.brands = data.get('brand_name', [])
     self.models = data.get('facet_model_name',[])
+    self.group_types = data.get('group_type',[])
     super(FacetedProductSearchForm, self).__init__(*args, **kwargs)
 
   def search(self):
     sqs = super(FacetedProductSearchForm, self).search()
     # The SearchQuerySet should only return Products and Data Documents
     sqs = sqs.filter(facet_model_name__in=['Data Document' ,'Product'])
+    print(sqs.facet_counts())
     if self.pucs:
         query = None
         for puc in self.pucs:
@@ -22,6 +24,15 @@ class FacetedProductSearchForm(FacetedSearchForm):
                 query = u''
             query += u'"%s"' % sqs.query.clean(puc)
         sqs = sqs.narrow(u'puc:%s' % query)
+    if self.group_types:
+        query = None
+        for group_type in self.group_types:
+            if query:
+                query += u' OR '
+            else:
+                query = u''
+            query += u'"%s"' % sqs.query.clean(group_type)
+        sqs = sqs.narrow(u'group_type:%s' % query)
     if self.brands:
         query = None
         for brand in self.brands:

--- a/templates/search/facet_search.html
+++ b/templates/search/facet_search.html
@@ -87,16 +87,14 @@
         {% endif %}
 
         <h3>Data Document Filters</h3>
-        <p><code>Document Type will be a facet: not yet implemented in DataDocument model</code></p>
-        <!-- TODO: the doc_type field has not yet been added to the DataDocumentModel -->
-        {% if facets.fields.source_type %}
+        {% if facets.fields.group_type %}
         <dl>
-        <dt>Filter by Document Type</dt>
-        {% for doc_type in facets.fields.source_type %}
-            {% if doc_type.1 != 0 %}
+        <dt>Filter by Group Type</dt>
+        {% for group_type in facets.fields.group_type %}
+            {% if group_type.1 != 0 %}
             <dd>
-            <input class="facet" id="{{source_type.0|cut:" "}}" type="checkbox" name="source_type" value="{{ source_type.0 }}" 
-            data-toggle="toggle" /> {{ source_type.0 }} ({{ source_type.1 }})
+            <input class="facet" id="{{group_type.0|cut:" "}}" type="checkbox" name="group_type" value="{{ group_type.0 }}" 
+            data-toggle="toggle" /> {{ group_type.0 }} ({{ group_type.1 }})
             </dd>
             {% endif %}
         {% endfor %}

--- a/templates/search/indexes/dashboard/data_document_text.txt
+++ b/templates/search/indexes/dashboard/data_document_text.txt
@@ -1,1 +1,2 @@
 {{object.title}}
+{{object.group_type}}


### PR DESCRIPTION
The search index now includes a new attribute for each data document. 

This is one example result:

```
{"_index":"product-index",
    "_type":"modelresult",
    "_id":"dashboard.datadocument.121831",
    "_score":1.0,
    "_source":{"id": "dashboard.datadocument.121831", 
               "django_ct": "dashboard.datadocument", 
               "django_id": "121831", 
               "text": "Odorono Powder Fresh Spray / (Omega &amp; Delta Co. Inc.)\n\n", 
               "title": "Odorono Powder Fresh Spray / (Omega & Delta Co. Inc.)", 
               "facet_model_name": "Data Document", 
               "facet_model_name_exact": "Data Document", 
               "group_type": "Unidentified", 
               "group_type_exact": "Unidentified", 
               "uploaded_at": "2017-08-09T11:30:00.090909", 
               "result_css_class": "datadocument-result", 
               "filename": "0f701691-0404-4b05-8073-9fb172f6da1e.pdf"}
}
```