### PR TITLE
filtering document_type dropdown on product linkage form

### DIFF
--- a/dashboard/tests/functional/test_chem_search.py
+++ b/dashboard/tests/functional/test_chem_search.py
@@ -31,7 +31,6 @@ class ChemSearchTest(TestCase):
 
     def test_chem_search(self):
         response = self.c.get('/chem_search/?chemical=dibutyl')
-        #print(response.content)
         self.assertContains(response, '"matchedDataDocuments": 1')
         self.assertContains(response, '"probableDataDocumentMatches": 55')
         self.assertNotContains(response, 'Sun_INDS_89')
@@ -43,7 +42,6 @@ class ChemSearchTest(TestCase):
     def test_chemical_search_ui_results(self):
         response = self.client.get('/findchemical/?q=ethyl').content.decode('utf8')
         response_html = html.fromstring(response)
-        print(response_html.xpath('string(/html/body/div[1]/div/div[2]/ol)'))
         self.assertIn('Sun_INDS_89',
                       response_html.xpath('string(/html/body/div[1]/div/div[2]/ol)'),
                       'The link to Sun_INDS_89 must be returned by a chemical search for "ethyl"')

--- a/dashboard/views/product_curation.py
+++ b/dashboard/views/product_curation.py
@@ -101,6 +101,9 @@ def link_product_form(request, pk, template_name=('product_curation/'
     ds_id = doc.data_group.data_source_id
     upc_stub = ('stub_' + str(Product.objects.all().count() + 1))
     form = ProductLinkForm(initial={'upc': upc_stub, 'document_type': doc.document_type})
+    # limit document type options to those matching parent datagroup group_type
+    form.fields['document_type'].queryset =\
+        form.fields['document_type'].queryset.filter(group_type_id = doc.data_group.group_type_id)
     if request.method == 'POST':
         form = ProductLinkForm(request.POST or None)
         if form.is_valid():


### PR DESCRIPTION
I didn't want to mess with seed data for this small fix. To see it in action on dev, replicate the test:

1. In the admin console, update datagroup "Walmart MSDS 1" (pk=17) to have the Group Type "composition" (group_type_id = 2)
2. Go to /link_product_form/129298 (datadocument 129298 belongs to the datagroup updated in step 1)
3. Verify that the Document Type dropdown contains only the 4 document_type options associated with the "composition" group type (group_type_id=2)
