### PR TITLE
test user redirected to /qa/ after last extext record approved

### DIFF
--- a/dashboard/tests/functional/test_extracted_qa.py
+++ b/dashboard/tests/functional/test_extracted_qa.py
@@ -23,3 +23,11 @@ class ExtractedQaTest(TestCase):
         ext = ExtractedText.objects.get(qa_group=qa_group)
         self.assertIsNotNone(ext.qa_group)
         response = self.client.get(f'/qa/extractedtext/{ext.pk}/')
+
+    def test_qa_approval_redirect(self):
+        # first need to create a QAGroup w/ this get request.
+        self.client.get(f'/qa/extractionscript/{self.objects.exscript.pk}/')
+        pk = self.objects.extext.pk
+        response = self.client.post(f'/qa/extractedtext/{pk}/',{'approve':[47]})
+        self.assertEqual(response.url, '/qa/',("User should be redirected to "
+                                "QA homepage after last extext is approved."))


### PR DESCRIPTION
a test added for a fix we implemented a while ago. all you should need to do to check this out is run the tests.