### PR TITLE
418 Conditional field display in QA page

### DIFF
--- a/dashboard/fixtures/02_datasource.yaml
+++ b/dashboard/fixtures/02_datasource.yaml
@@ -1,4 +1,9 @@
 - model: dashboard.datasource
+  pk: 6
+  fields: {created_at: !!timestamp '2018-09-09 11:31:21.121027', updated_at: !!timestamp '2018-09-23
+      06:30:04.484498', title: Functional Use Example Source, url: '',
+    estimated_records: 3, state: CO, description: '', priority: LO}
+- model: dashboard.datasource
   pk: 7
   fields: {created_at: !!timestamp '2018-03-09 11:31:21.121027', updated_at: !!timestamp '2018-05-27
       06:30:04.484498', title: British Petroleum (Air), url: 'https://airbpmsds.bp.com/msdspds/airbpmsdspds.nsf/BPHomePage?OpenForm&sitelang=EN',

--- a/dashboard/fixtures/03_datagroup.yaml
+++ b/dashboard/fixtures/03_datagroup.yaml
@@ -1,4 +1,11 @@
 - model: dashboard.datagroup
+  pk: 5
+  fields: {created_at: !!timestamp '2018-08-11 07:00:37.681930', updated_at: !!timestamp '2018-09-20
+      12:16:49.053559', name: Functional Use Example Group 1, description: '', downloaded_by: 1,
+    downloaded_at: !!timestamp '2018-08-09 11:31:35', download_script: null, data_source: 6,
+    csv: null,
+    zip_file: media/test_func_use/test_func_use.zip, group_type: 3}
+- model: dashboard.datagroup
   pk: 6
   fields: {created_at: !!timestamp '2018-05-11 07:00:37.681930', updated_at: !!timestamp '2018-06-20
       12:16:49.053559', name: British Petroleum (Air) 1, description: '', downloaded_by: 1,

--- a/dashboard/fixtures/06_datadocument.yaml
+++ b/dashboard/fixtures/06_datadocument.yaml
@@ -1,4 +1,10 @@
 - model: dashboard.datadocument
+  pk: 5
+  fields: {created_at: null, updated_at: null, filename: test_functional_use_1.pdf, title: Test Functional Use Doc 1,
+    url: '', raw_category: '', data_group: 5, matched: true, extracted: true,
+    created_at: !!timestamp '2018-08-21 13:16:47.965719', document_type: null, organization: ''}
+
+- model: dashboard.datadocument
   pk: 156051
   fields: {created_at: null, updated_at: null, filename: Sun_INDS_89.pdf, title: Sun_INDS_89,
     url: '', raw_category: '', data_group: 22, matched: true, extracted: false,

--- a/dashboard/fixtures/07_script.yaml
+++ b/dashboard/fixtures/07_script.yaml
@@ -62,3 +62,13 @@
   pk: 13
   fields: {created_at: !!timestamp '2018-07-31 11:28:13.705077', updated_at: !!timestamp '2018-07-31
       11:28:13.705115', title: Manual (dummy), url: null, qa_begun: false, script_type: EX}
+- model: dashboard.script
+  pk: 14
+  fields: {created_at: !!timestamp '2018-09-11 07:00:37.838615', updated_at: !!timestamp '2018-09-11
+      07:00:37.875755', title: Functional Use Download Script, url: 'https://github.com/HumanExposure/data_mgmt_scripts/blob/master/download_GeorgiaPacific.ipynb',
+    qa_begun: false, script_type: DL}
+- model: dashboard.script
+  pk: 15
+  fields: {created_at: !!timestamp '2018-09-11 07:00:37.838615', updated_at: !!timestamp '2018-09-11
+      07:00:37.875755', title: Functional Use Extraction Script, url: 'https://github.com/HumanExposure/data_mgmt_scripts/blob/master/download_GeorgiaPacific.ipynb',
+    qa_begun: false, script_type: EX}

--- a/dashboard/fixtures/08_extractedtext.yaml
+++ b/dashboard/fixtures/08_extractedtext.yaml
@@ -1,4 +1,11 @@
 - model: dashboard.extractedtext
+  pk: 5
+  fields: {created_at: null, updated_at: null, prod_name: Product with functional use,
+    doc_date: '2018-04-07', rev_num: null, extraction_script: 15, qa_checked: false,
+    qa_edited: false, qa_approved_date: null, qa_approved_by: null,
+    qa_group: null}
+
+- model: dashboard.extractedtext
   pk: 156051
   fields: {created_at: null, updated_at: null, prod_name: Sun_INDS_89,
     doc_date: '2018-04-07', rev_num: '47', extraction_script: 6, qa_checked: false,

--- a/dashboard/fixtures/10_extractedchemical.yaml
+++ b/dashboard/fixtures/10_extractedchemical.yaml
@@ -14,7 +14,24 @@
   fields: {created_at: null, updated_at: null, extracted_text: 7, raw_cas: 84-74-2,
     raw_chem_name: dibutyl phthalate, raw_min_comp: '4', raw_max_comp: '7', unit_type: 1,
     report_funcuse: swell, weight_fraction_type: 1, ingredient_rank: null, raw_central_comp: ''}
+
+
+
 - model: dashboard.extractedchemical
+  pk: 6
+  fields: {created_at: !!timestamp '2018-09-06 07:16:07', updated_at: !!timestamp '2018-09-06
+      07:16:07', extracted_text: 5, raw_cas: 520-45-7, raw_chem_name: Fictional acid, 
+      raw_min_comp: null, raw_max_comp: null, unit_type: 1,
+      report_funcuse: surfactant, weight_fraction_type: 1, ingredient_rank: null, raw_central_comp: null}
+
+- model: dashboard.extractedchemical
+  pk: 7
+  fields: {created_at: !!timestamp '2018-09-06 07:17:07', updated_at: !!timestamp '2018-09-06
+      07:17:07', extracted_text: 5, raw_cas: 520-45-8, raw_chem_name: Fictional acid 2, 
+      raw_min_comp: null, raw_max_comp: null, unit_type: 1,
+      report_funcuse: surfactant, weight_fraction_type: 1, ingredient_rank: null, raw_central_comp: null}
+
+
   pk: 8
   fields: {created_at: !!timestamp '2018-06-06 07:14:52', updated_at: !!timestamp '2018-06-06
       07:14:52', extracted_text: 8, raw_cas: 84-74-2, raw_chem_name: dibutyl phthalate,

--- a/dashboard/fixtures/15_extractedfunctionaluse.yaml
+++ b/dashboard/fixtures/15_extractedfunctionaluse.yaml
@@ -5,4 +5,4 @@
 - model: dashboard.extractedfunctionaluse
   pk: 2
   fields: {created_at: !!timestamp '2018-09-06 07:16:07', updated_at: !!timestamp '2018-09-06
-      07:16:07', extracted_text: 5, raw_cas: 520-45-6, raw_chem_name: Functiona2 Use Chem2, report_funcuse: fragrance}
+      07:16:07', extracted_text: 5, raw_cas: 520-45-6, raw_chem_name: Functional Use Chem2, report_funcuse: fragrance}

--- a/dashboard/fixtures/15_extractedfunctionaluse.yaml
+++ b/dashboard/fixtures/15_extractedfunctionaluse.yaml
@@ -1,10 +1,8 @@
 - model: dashboard.extractedfunctionaluse
   pk: 1
   fields: {created_at: !!timestamp '2018-09-06 07:16:07', updated_at: !!timestamp '2018-09-06
-      07:16:07', extracted_text: 5, raw_cas: 520-45-6, raw_chem_name: Dehydroacetic
-      acid, report_funcuse: surfactant}
+      07:16:07', extracted_text: 5, raw_cas: 520-45-6, raw_chem_name: Functional Use Chem1, report_funcuse: surfactant}
 - model: dashboard.extractedfunctionaluse
   pk: 2
   fields: {created_at: !!timestamp '2018-09-06 07:16:07', updated_at: !!timestamp '2018-09-06
-      07:16:07', extracted_text: 5, raw_cas: 520-45-6, raw_chem_name: Dehydroacetic
-      acid, report_funcuse: fragrance}
+      07:16:07', extracted_text: 5, raw_cas: 520-45-6, raw_chem_name: Functiona2 Use Chem2, report_funcuse: fragrance}

--- a/dashboard/fixtures/15_extractedfunctionaluse.yaml
+++ b/dashboard/fixtures/15_extractedfunctionaluse.yaml
@@ -1,0 +1,10 @@
+- model: dashboard.extractedfunctionaluse
+  pk: 1
+  fields: {created_at: !!timestamp '2018-09-06 07:16:07', updated_at: !!timestamp '2018-09-06
+      07:16:07', extracted_text: 5, raw_cas: 520-45-6, raw_chem_name: Dehydroacetic
+      acid, report_funcuse: surfactant}
+- model: dashboard.extractedfunctionaluse
+  pk: 2
+  fields: {created_at: !!timestamp '2018-09-06 07:16:07', updated_at: !!timestamp '2018-09-06
+      07:16:07', extracted_text: 5, raw_cas: 520-45-6, raw_chem_name: Dehydroacetic
+      acid, report_funcuse: fragrance}

--- a/dashboard/fixtures/load_fixtures.sh
+++ b/dashboard/fixtures/load_fixtures.sh
@@ -7,8 +7,8 @@ python manage.py loaddata 00_superuser 01_lookups \
     02_datasource 03_datagroup 04_PUC 05_product \
     06_datadocument 07_script 08_extractedtext \
     09_productdocument 10_extractedchemical \
-    11_dsstoxsubstance 12_habits_and_practices 13_habits_and_practices_to_puc
+    11_dsstoxsubstance 12_habits_and_practices 13_habits_and_practices_to_puc 15_extractedfunctionaluse
 
 
 # some shells prefer one line
-python manage.py loaddata 00_superuser 01_lookups 02_datasource 03_datagroup 04_PUC 05_product 06_datadocument 07_script 08_extractedtext   09_productdocument 10_extractedchemical  11_dsstoxsubstance 12_habits_and_practices 13_habits_and_practices_to_puc
+python manage.py loaddata 00_superuser 01_lookups 02_datasource 03_datagroup 04_PUC 05_product 06_datadocument 07_script 08_extractedtext   09_productdocument 10_extractedchemical  11_dsstoxsubstance 12_habits_and_practices 13_habits_and_practices_to_puc 15_extractedfunctionaluse.yaml

--- a/dashboard/tests/functional/test_qa_seed_data.py
+++ b/dashboard/tests/functional/test_qa_seed_data.py
@@ -48,6 +48,8 @@ class TestQaPage(TestCase):
         self.assertIn(b'<input type="text" name="details-1-raw_cas"', response.content)
         # There should not be any unit_type field in the functional use QA display
         self.assertNotIn(b'<input type="text" name="details-1-unit_type"', response.content)
+        # The values shown should match the functional use record, not the chemical record
+        self.assertIn(b'Functional Use Chem1', response.content)
 
         # Go back to a different ExtractionScript
         response = self.client.get('/qa/extractionscript/5', follow=True)
@@ -55,6 +57,7 @@ class TestQaPage(TestCase):
         response = self.client.get('/qa/extractedtext/7/', follow=True)
         # This page should include a unit_type input form
         self.assertIn(b'details-1-unit_type', response.content)
+
         
 
 

--- a/dashboard/tests/functional/test_qa_seed_data.py
+++ b/dashboard/tests/functional/test_qa_seed_data.py
@@ -3,15 +3,16 @@ from django.test import TestCase, override_settings, RequestFactory
 from dashboard.models import DataDocument, Script, ExtractedText, ExtractedChemical, QAGroup
 
 @override_settings(ALLOWED_HOSTS=['testserver'])
-class TestQaApproval(TestCase):
+class TestQaPage(TestCase):
     fixtures = ['00_superuser.yaml','01_lookups.yaml',
     '02_datasource.yaml','03_datagroup.yaml',
     '04_PUC.yaml','05_product.yaml',
     '06_datadocument.yaml','07_script.yaml',
     '08_extractedtext.yaml','09_productdocument.yaml',
-    '10_extractedchemical.yaml', '11_dsstoxsubstance.yaml']
+    '10_extractedchemical.yaml', '11_dsstoxsubstance.yaml',
+    '15_extractedfunctionaluse.yaml']
+
     def setUp(self):
-        print('setUp running')
         self.factory = RequestFactory()
         self.client.login(username='karyn', password='specialP@55word')
 
@@ -34,7 +35,31 @@ class TestQaApproval(TestCase):
         # Follow the first approval link
         response = self.client.get('/qa/extractedtext/7', follow=True)
         print(response.context['extracted_text'])
+
         
+    def test_hidden_fields(self):
+        '''ExtractionScript 15 includes a functional use data group with pk = 5.
+        Its QA page should hide the composition fields '''
+        # Create the QA group by opening the Script's page
+        response = self.client.get('/qa/extractionscript/15', follow=True)
+        # Open the DataGroup's first QA approval link
+        response = self.client.get('/qa/extractedtext/5/', follow=True)
+        # A raw_cas field should be in the page
+        self.assertIn(b'<input type="text" name="chemicals-1-raw_cas"', response.content)
+        # There should not be any unit_type field in the functional use QA display
+        self.assertNotIn(b'<input type="text" name="chemicals-1-unit_type"', response.content)
+
+        # Go back to a different ExtractionScript
+        response = self.client.get('/qa/extractionscript/5', follow=True)
+        # Open the QA page for a non-FunctionalUse document
+        response = self.client.get('/qa/extractedtext/7/', follow=True)
+        # This page should include a unit_type input form
+        self.assertIn(b'chemicals-1-unit_type', response.content)
+        
+
+
+
+
         
 
 

--- a/dashboard/tests/functional/test_qa_seed_data.py
+++ b/dashboard/tests/functional/test_qa_seed_data.py
@@ -45,16 +45,16 @@ class TestQaPage(TestCase):
         # Open the DataGroup's first QA approval link
         response = self.client.get('/qa/extractedtext/5/', follow=True)
         # A raw_cas field should be in the page
-        self.assertIn(b'<input type="text" name="chemicals-1-raw_cas"', response.content)
+        self.assertIn(b'<input type="text" name="details-1-raw_cas"', response.content)
         # There should not be any unit_type field in the functional use QA display
-        self.assertNotIn(b'<input type="text" name="chemicals-1-unit_type"', response.content)
+        self.assertNotIn(b'<input type="text" name="details-1-unit_type"', response.content)
 
         # Go back to a different ExtractionScript
         response = self.client.get('/qa/extractionscript/5', follow=True)
         # Open the QA page for a non-FunctionalUse document
         response = self.client.get('/qa/extractedtext/7/', follow=True)
         # This page should include a unit_type input form
-        self.assertIn(b'chemicals-1-unit_type', response.content)
+        self.assertIn(b'details-1-unit_type', response.content)
         
 
 

--- a/dashboard/views/extraction_script.py
+++ b/dashboard/views/extraction_script.py
@@ -16,7 +16,7 @@ from django.core.files.storage import FileSystemStorage
 from django.contrib.auth.decorators import login_required
 
 from dashboard.models import (DataGroup, DataDocument, DataSource, QANotes,
-                              ExtractedText, Script, QAGroup, ExtractedChemical)
+                              ExtractedText, Script, QAGroup, ExtractedChemical, ExtractedFunctionalUse)
 
 
 class ExtractionScriptForm(ModelForm):
@@ -54,20 +54,19 @@ class QANotesForm(ModelForm):
 
 
 
-class BaseExtractedChemicalFormSet(BaseInlineFormSet):
+class BaseExtractedDetailFormSet(BaseInlineFormSet):
     """
-    Base class for the form in which users edit the chemical composition data
+    Base class for the form in which users edit the chemical composition or functional use data
     """
     required_css_class = 'required'  # adds to label tag
 
     class Meta:
         model = ExtractedChemical
-        # fields = ['raw_cas', 'raw_chem_name', 'raw_min_comp',
-        #           'raw_max_comp', 'unit_type', 'report_funcuse', 'extracted_text']
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user', None)
-        super(BaseExtractedChemicalFormSet, self).__init__(*args, **kwargs)
+        super(BaseExtractedDetailFormSet, self).__init__(*args, **kwargs)
+
         for form in self.forms:
             for field in form.fields:
                 form.fields[field].widget.attrs.update(
@@ -169,46 +168,60 @@ def extracted_text_qa(request, pk,
     a = extext.qa_group.get_approved_doc_count()
     r = ExtractedText.objects.filter(qa_group=extext.qa_group).count() - a
     stats = '%s document(s) approved, %s documents remaining' % (a, r)
-    # Create the formset factory for the extracted chemical records
-    ChemFormSet = inlineformset_factory(parent_model=ExtractedText,
-                                        model=ExtractedChemical,
-                                        formset=BaseExtractedChemicalFormSet,
-                                        fields=['extracted_text','raw_cas',
-                                                'raw_chem_name', 'raw_min_comp',
-                                                'raw_max_comp', 'unit_type',
-                                                'report_funcuse',
-                                                'ingredient_rank',
-                                                'raw_central_comp'],
+
+    # Create the formset factory for the extracted records
+    # The model used for the formset depends on whether the 
+    # extracted text object matches a data document 
+    dg_type = datadoc.data_group.group_type.title
+    if (dg_type == 'Functional use'): 
+        detail_model = ExtractedFunctionalUse
+        detail_fields = ['extracted_text','raw_cas',
+                        'raw_chem_name', 
+                        'report_funcuse'
+                        ]
+    else:
+        detail_model = ExtractedChemical
+        detail_fields = ['extracted_text','raw_cas',
+                        'raw_chem_name', 'raw_min_comp',
+                        'raw_max_comp', 'unit_type',
+                        'report_funcuse',
+                        'ingredient_rank',
+                        'raw_central_comp']
+
+    DetailFormSet = inlineformset_factory(parent_model=ExtractedText,
+                                        model=detail_model,
+                                        formset=BaseExtractedDetailFormSet,
+                                        fields=detail_fields,
                                                 extra=1)
     ext_form =  ExtractedTextForm(instance=extext)
     note, created = QANotes.objects.get_or_create(extracted_text=extext)
     notesform =  QANotesForm(instance=note)
-    chem_formset = ChemFormSet(instance=extext, prefix='chemicals')
+    detail_formset = DetailFormSet(instance=extext, prefix='chemicals')
     context = {
         'extracted_text': extext,
         'doc': datadoc,
         'script': exscript,
         'stats': stats,
         'nextid': nextid,
-        'chem_formset': chem_formset,
+        'detail_formset': detail_formset,
         'notesform': notesform,
         'ext_form': ext_form
         }
 
     if request.method == 'POST' and 'save' in request.POST:
         print('---saving')
-        chem_formset = ChemFormSet(request.POST, instance=extext,
+        detail_formset = DetailFormSet(request.POST, instance=extext,
                                                         prefix='chemicals')
         ext_form =  ExtractedTextForm(request.POST, instance=extext)
         notesform = QANotesForm(request.POST, instance=note)
-        if chem_formset.has_changed() or ext_form.has_changed():
+        if detail_formset.has_changed() or ext_form.has_changed():
             print(str(extext.qa_edited))
-            if chem_formset.is_valid() and ext_form.is_valid():
-                chem_formset.save()
+            if detail_formset.is_valid() and ext_form.is_valid():
+                detail_formset.save()
                 ext_form.save()
                 extext.qa_edited = True
                 extext.save()
-        context['chem_formset'] = chem_formset
+        context['detail_formset'] = detail_formset
         context['ext_form'] = ext_form
         # context['notesform'] = notesform
         context.update({'notesform' : notesform}) # calls the clean method? y?

--- a/dashboard/views/extraction_script.py
+++ b/dashboard/views/extraction_script.py
@@ -196,7 +196,7 @@ def extracted_text_qa(request, pk,
     ext_form =  ExtractedTextForm(instance=extext)
     note, created = QANotes.objects.get_or_create(extracted_text=extext)
     notesform =  QANotesForm(instance=note)
-    detail_formset = DetailFormSet(instance=extext, prefix='chemicals')
+    detail_formset = DetailFormSet(instance=extext, prefix='details')
     context = {
         'extracted_text': extext,
         'doc': datadoc,
@@ -211,7 +211,7 @@ def extracted_text_qa(request, pk,
     if request.method == 'POST' and 'save' in request.POST:
         print('---saving')
         detail_formset = DetailFormSet(request.POST, instance=extext,
-                                                        prefix='chemicals')
+                                                        prefix='details')
         ext_form =  ExtractedTextForm(request.POST, instance=extext)
         notesform = QANotesForm(request.POST, instance=note)
         if detail_formset.has_changed() or ext_form.has_changed():

--- a/templates/qa/extracted_text_qa.html
+++ b/templates/qa/extracted_text_qa.html
@@ -74,7 +74,12 @@
       <div class="card-header form-inline">
         <h3 class="text-center col-9">Extracted Text</h3>
       <button type="button" id="btn-toggle-edit" data-toggle="button" class="btn btn-secondary" onclick="toggleChemicalEdit(true)">
-              <span id="btn-toggle-label" class="oi oi-wrench"></span>Edit Extracted Chemicals
+              <span id="btn-toggle-label" class="oi oi-wrench"></span>
+              {% if doc.data_group.group_type.title != "Functional use" %}
+              Edit Extracted Chemicals
+              {% else %}
+              Edit Extracted Functional Use Records
+              {% endif %}
       </button>
       </div>
       <div class="card-body">

--- a/templates/qa/extracted_text_qa.html
+++ b/templates/qa/extracted_text_qa.html
@@ -94,8 +94,8 @@
               {% include 'core/bs4_form_dl.html' with form=ext_form %}
           </div>
         </div>
-        {{ chem_formset.management_form }}
-        {% for form in chem_formset.forms %}
+        {{ detail_formset.management_form }}
+        {% for form in detail_formset.forms %}
         <div class="col-sm-3">
           <div class="card" >
             <div class="card-body bg-secondary">

--- a/templates/qa/extracted_text_qa.html
+++ b/templates/qa/extracted_text_qa.html
@@ -2,6 +2,9 @@
 {% load widget_tweaks %}
 {% load staticfiles %}'
 
+{% block title %}QA Data Document {{doc.id}}: {{doc.title}}{% endblock %}
+
+
 {% load humanize %}
 {% if messages %}
     {% for message in messages %}
@@ -32,6 +35,12 @@
           <a title="Data Group"
               href="{% url 'data_group_detail' doc.data_group.id %}"> {{ doc.data_group }}
           </a>
+        </td>
+      </tr>
+      <tr>
+        <th>Document Type</th>
+        <td>
+          {{ doc.document_type }}
         </td>
       </tr>
       <tr>
@@ -108,6 +117,8 @@
                 <small><b>{{ form.raw_chem_name.label_tag }}</b></small><br>
                   {{ form.raw_chem_name}}
               </div>
+
+        {% if doc.data_group.group_type.title != "Functional use" %}
               <div class="text-center">
                 <small><b>{{ form.raw_min_comp.label_tag }}</b></small><br>
                   {{ form.raw_min_comp}}
@@ -128,15 +139,17 @@
                 {% else %}
                   {{ form.unit_type }}
                 {% endif %}
+            <div class="text-center">
+                <small><b>{{ form.ingredient_rank.label_tag }}</b></small><br>
+                    {{ form.ingredient_rank}}
+            </div>
+        </div>
+        {% endif  %}
 
-              </div>
+
               <div class="text-center">
                 <small><b>{{ form.report_funcuse.label_tag }}</b></small><br>
                   {{ form.report_funcuse}}
-              </div>
-              <div class="text-center">
-                <small><b>{{ form.ingredient_rank.label_tag }}</b></small><br>
-                  {{ form.ingredient_rank}}
               </div>
               <div class="text-center">
                 {% if form.instance.pk %}

--- a/templates/qa/extraction_script.html
+++ b/templates/qa/extraction_script.html
@@ -12,6 +12,7 @@
     <thead class="table-primary">
         <th>ID</th>
         <th>Data Group</th>
+        <th>Group Type</th>
         <th>Data Document</th>
         <th>Document Date</th>
         <th>Revision Number</th>
@@ -27,6 +28,7 @@
             href="{% url "data_group_detail" extractedtext.data_document.data_group.id %}"> {{ extractedtext.data_document.data_group.name }}
           </a>
         </td>
+        <td>{{ extractedtext.data_document.data_group.group_type }}</td>
         <td>{{ extractedtext.data_document }}</td>
         <td>{{ extractedtext.doc_date }}</td>
         <td>{{ extractedtext.rev_num }}</td>


### PR DESCRIPTION
The `extracted_text_qa.html` template now checks to see if the data document belongs to a data group whose group type is "Functional use." If it is not, then the template includes the fields specified in the ticket. Otherwise, it does not render those fields. 

The seed data yaml files now include an Extraction Script, a Data Group, a DataDocument, and two new ExtractedChemical records. I also added an ExtractedFunctionalUse object, but it's not used here.

There are two different test classes for the QA page. I modified the one that uses the seed data for testing this issue, and renamed it to clarify why we have two files. 

I'm not entirely happy with this check in the template:
`{% if doc.data_group.group_type.title != "Functional use" %} `

I don't like hardcoding the case-sensitive title of the GroupType object, but I also don't want to use an id. Should we modify the GroupType class to use a defined set of choices? This is the canonical example from the Django docs:
```
class Student(models.Model):
    FRESHMAN = 'FR'
    SOPHOMORE = 'SO'
    JUNIOR = 'JR'
    SENIOR = 'SR'
    YEAR_IN_SCHOOL_CHOICES = (
        (FRESHMAN, 'Freshman'),
        (SOPHOMORE, 'Sophomore'),
        (JUNIOR, 'Junior'),
        (SENIOR, 'Senior'),
    )
```