### PR TITLE
Update requirements.txt to use compatible versions of widgets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 certifi
-Django>=2.0.7,<2.1.0
+Django>=2.1.2
 pytz==2017.2
 PyYAML==3.12
 wincertstore==0.2
-django-autocomplete-light==3.2.10
+django-autocomplete-light==3.3.2
 django-debug-toolbar==1.9.1
 django-haystack>=2.7.0
 django-haystack-elasticsearch>=0.1.0
@@ -12,6 +12,6 @@ django-queryset-csv>=1.0.0
 docutils>=0.12
 elasticsearch-dsl>=2.0.0,<3.0.0
 elasticsearch>=2.0.0,<3.0.0
-django-bootstrap-datepicker-plus==3.0.4
+django-bootstrap-datepicker-plus==3.0.5
 selenium>=3.11.0
 lxml>=4.2.2


### PR DESCRIPTION
Both of the packages that broke as a result of the Django 2.1 changes have been updated and can be automatically updated with pip.

Run `pip install --upgrade -r requirements.txt`