### PR TITLE
#199 override get_queryset for size option

### DIFF
--- a/dashboard/tests/functional/test_faceted_search.py
+++ b/dashboard/tests/functional/test_faceted_search.py
@@ -33,3 +33,10 @@ class FacetedSearchTest(TestCase):
         response = self.c.get('/find/?q=terro')
         self.assertContains(response, '<table')
         self.assertContains(response, '<th>Record</th>')
+
+    def test_product_facet_returns(self):
+        response = self.c.get('/find/?q=insecticide')
+        brands = response.content.count(b'name="brand_name"')
+        # default set to options = {"size": 0} in /dashboard/views/search.py
+        self.assertTrue(brands>10, ('There should be ~143 product returns '
+                                                        'for this search term'))

--- a/dashboard/views/search.py
+++ b/dashboard/views/search.py
@@ -27,3 +27,9 @@ class FacetedSearchView(BaseFacetedSearchView):
     template_name = 'search/facet_search.html'
     paginate_by = 20
     context_object_name = 'object_list'
+    def get_queryset(self):
+        options = {"size": 0} # capped @ 100 ????
+        qs = super().get_queryset()
+        for field in self.facet_fields:
+            qs = qs.facet(field, **options)
+        return qs


### PR DESCRIPTION
#199
returns all `products` now, check `/find/?q=insecticide`