### PR TITLE
Ticket 470: Handle absent extracted text

### DIFF
--- a/dashboard/tests/functional/test_datadocument_detail.py
+++ b/dashboard/tests/functional/test_datadocument_detail.py
@@ -37,6 +37,12 @@ class DataDocumentDetailTest(TestCase):
         dd.refresh_from_db()
         self.assertEqual(dd.document_type_id, 2,
                          'DataDocument 7 should have a final document_type_id of 2')
+    
+    def test_absent_extracted_text(self):
+        resp = self.client.get('/datadocument/155324')
+        self.assertEqual(resp.status_code, 200, 'The page must return a 200 status code')
+
+
 
 class TestDynamicDetailFormsets(TestCase):
     fixtures = fixtures_standard
@@ -72,16 +78,4 @@ class TestDynamicDetailFormsets(TestCase):
             childform_model = child_formset.__dict__.get('queryset').__dict__.get('model')
             self.assertEqual(dd_child_model, childform_model)
 
-            
 
-
-        print('\nprint(some very important test output)')
-        print('|￣￣￣￣￣|')
-        print('|   HI      |')
-        print('|           |' )
-        print('|  RICK     |' )
-        print('|           |')
-        print('|___________|')
-        print('(\__/) || ')
-        print('(•ㅅ•) || ')
-        print('/ 　 づ')

--- a/dashboard/tests/functional/test_datadocument_detail.py
+++ b/dashboard/tests/functional/test_datadocument_detail.py
@@ -39,8 +39,20 @@ class DataDocumentDetailTest(TestCase):
                          'DataDocument 7 should have a final document_type_id of 2')
     
     def test_absent_extracted_text(self):
-        resp = self.client.get('/datadocument/155324')
+        resp = self.client.get('/datadocument/155324/')
         self.assertEqual(resp.status_code, 200, 'The page must return a 200 status code')
+        for dd in DataDocument.objects.all():
+            ddid = dd.id 
+            resp = self.client.get('/datadocument/%s/' % ddid)
+            print('Opening /datadocument/%s/' % ddid)
+            self.assertEqual(resp.status_code, 200, 'The page must return a 200 status code')
+            try:
+                extracted_text = ExtractedText.objects.get(data_document=dd)
+                self.assertContains(resp, '<h4>Extracted Text</h4>')
+            except ExtractedText.DoesNotExist:
+                self.assertNotContains(resp, '<h4>Extracted Text</h4>')
+
+
 
 
 

--- a/dashboard/tests/functional/test_datadocument_detail.py
+++ b/dashboard/tests/functional/test_datadocument_detail.py
@@ -39,21 +39,17 @@ class DataDocumentDetailTest(TestCase):
                          'DataDocument 7 should have a final document_type_id of 2')
     
     def test_absent_extracted_text(self):
-        resp = self.client.get('/datadocument/155324/')
-        self.assertEqual(resp.status_code, 200, 'The page must return a 200 status code')
+        # Check every data document and confirm that its detail page loads,
+        # with or without a detail formset
         for dd in DataDocument.objects.all():
             ddid = dd.id 
             resp = self.client.get('/datadocument/%s/' % ddid)
-            print('Opening /datadocument/%s/' % ddid)
             self.assertEqual(resp.status_code, 200, 'The page must return a 200 status code')
             try:
                 extracted_text = ExtractedText.objects.get(data_document=dd)
                 self.assertContains(resp, '<h4>Extracted Text</h4>')
             except ExtractedText.DoesNotExist:
                 self.assertNotContains(resp, '<h4>Extracted Text</h4>')
-
-
-
 
 
 class TestDynamicDetailFormsets(TestCase):

--- a/dashboard/views/data_document.py
+++ b/dashboard/views/data_document.py
@@ -14,30 +14,44 @@ from dashboard.models import *
 def data_document_detail(request, pk,
                          template_name='data_document/data_document_detail.html'):
     doc = get_object_or_404(DataDocument, pk=pk, )
-    # TODO: this needs to account for the absence of an ExtractedText object
-    # https://github.com/HumanExposure/factotum/issues/470
-    extracted_text = ExtractedText.objects.get(data_document=doc)
     ParentForm, ChildForm = create_detail_formset(doc.data_group.type, EXTRA)
-    extracted_text = extracted_text.pull_out_cp() #get CP if exists
-    extracted_text_form = ParentForm(instance=extracted_text)
-    child_formset = ChildForm(instance=extracted_text)
+
     document_type_form = DocumentTypeForm(request.POST or None, instance=doc)
     qs = DocumentType.objects.filter(group_type=doc.data_group.group_type)
     document_type_form.fields['document_type'].queryset = qs
-    if request.method== 'POST':
-        child_formset = ChildForm(request.POST, instance=extracted_text)
-        if child_formset.is_valid() and child_formset.has_changed():
-            child_formset.save()
-            child_formset = ChildForm(instance=extracted_text) # load extra form
-    colors = ['#d6d6a6','#dfcaa9','#d8e5bf'] * 47
-    color = (hex for hex in colors)
-    for form in child_formset.forms:
-        form.color = next(color)
+
     context = {'doc': doc,
-            'extracted_text': extracted_text,
-            'extracted_text_form': extracted_text_form,
-            'detail_formset': child_formset,
             'document_type_form': document_type_form}
+
+    # TODO: this needs to account for the absence of an ExtractedText object
+    # https://github.com/HumanExposure/factotum/issues/470
+    #extracted_text = ExtractedText.objects.get(data_document=doc)
+    try:
+        extracted_text = ExtractedText.objects.get(data_document=doc)
+        print('ExtractedText object found: %s' % extracted_text )
+        extracted_text = extracted_text.pull_out_cp() #get CP if exists
+        extracted_text_form = ParentForm(instance=extracted_text)
+        child_formset = ChildForm(instance=extracted_text)
+
+        context.update(
+            {'extracted_text': extracted_text,
+            'extracted_text_form': extracted_text_form,
+            'detail_formset': child_formset}
+            )
+        if request.method== 'POST':
+            child_formset = ChildForm(request.POST, instance=extracted_text)
+            if child_formset.is_valid() and child_formset.has_changed():
+                child_formset.save()
+                child_formset = ChildForm(instance=extracted_text) # load extra form
+                colors = ['#d6d6a6','#dfcaa9','#d8e5bf'] * 47
+                color = (hex for hex in colors)
+                for form in child_formset.forms:
+                    form.color = next(color)
+
+    except ExtractedText.DoesNotExist:
+        print('No ExtractedText object found for DataDocument: %s' % doc )
+        extracted_text = None
+
     return render(request, template_name, context)
 
 @login_required()

--- a/dashboard/views/data_document.py
+++ b/dashboard/views/data_document.py
@@ -43,10 +43,11 @@ def data_document_detail(request, pk,
             if child_formset.is_valid() and child_formset.has_changed():
                 child_formset.save()
                 child_formset = ChildForm(instance=extracted_text) # load extra form
-                colors = ['#d6d6a6','#dfcaa9','#d8e5bf'] * 47
-                color = (hex for hex in colors)
-                for form in child_formset.forms:
-                    form.color = next(color)
+                
+        colors = ['#d6d6a6','#dfcaa9','#d8e5bf'] * 47
+        color = (hex for hex in colors)
+        for form in child_formset.forms:
+            form.color = next(color)
 
     except ExtractedText.DoesNotExist:
         #print('No ExtractedText object found for DataDocument: %s' % doc )

--- a/dashboard/views/data_document.py
+++ b/dashboard/views/data_document.py
@@ -28,7 +28,7 @@ def data_document_detail(request, pk,
     #extracted_text = ExtractedText.objects.get(data_document=doc)
     try:
         extracted_text = ExtractedText.objects.get(data_document=doc)
-        print('ExtractedText object found: %s' % extracted_text )
+        #print('ExtractedText object found: %s' % extracted_text )
         extracted_text = extracted_text.pull_out_cp() #get CP if exists
         extracted_text_form = ParentForm(instance=extracted_text)
         child_formset = ChildForm(instance=extracted_text)
@@ -49,7 +49,7 @@ def data_document_detail(request, pk,
                     form.color = next(color)
 
     except ExtractedText.DoesNotExist:
-        print('No ExtractedText object found for DataDocument: %s' % doc )
+        #print('No ExtractedText object found for DataDocument: %s' % doc )
         extracted_text = None
 
     return render(request, template_name, context)

--- a/dashboard/views/data_group.py
+++ b/dashboard/views/data_group.py
@@ -41,6 +41,7 @@ def data_group_detail(request, pk,
     page = request.GET.get('page')
     paginator = Paginator(docs, 50) # TODO: make this dynamic someday in its own ticket
     store = settings.MEDIA_URL + str(dg.fs_id)
+    # TODO: test to see if this handles DoesNotExist
     ext = ExtractedText.objects.filter(data_document_id__in=docs).first()
     context = { 'datagroup'      : dg,
                 'documents'      : paginator.page(1 if page is None else page),

--- a/templates/data_document/data_document_detail.html
+++ b/templates/data_document/data_document_detail.html
@@ -71,9 +71,9 @@
     {% endif %}
 
     <div class="col-sm-6 extracted-text">
-    {% if extracted_text_form %}
     <h4>Extracted Text</h4>
     <div class="card-body border">
+        {% if extracted_text_form %}
         {% if extracted_text_form.errors %}
             <div class="form-group has-error">
                 <span class="help-block">{{ extracted_text_form.errors }}</span>
@@ -112,8 +112,10 @@
             <button type="submit" id="save_extracted_text" name="save_extracted_text"
                     class="btn btn-primary chem-control" role="button">Save edits</button>
         </form>
-        </div>
+        {% else %}
+            No Extracted Text exists for this Data Document
         {% endif %}
+        </div>
     </div>
     </div>
 
@@ -161,13 +163,3 @@
 </form>
 {% endif %}
 {% endblock %}
-<!-- if we need to be more specific with the way cards are layed out.....
-{%  if doc.data_group.is_chemical_presence %}
-    {% include "data_document/chemical_presence_cards.html" %}
-{%  elif doc.data_group.is_habits_and_practices %}
-    {% include "data_document/habits_and_pra_cards.html" %}
-{%  elif doc.data_group.is_composition %}
-    {% include "data_document/chemical_cards.html" %}
-{%  elif doc.data_group.is_functional_use %}
-    {% include "data_document/functional_use_cards.html" %}
-{% endif %} -->

--- a/templates/data_document/data_document_detail.html
+++ b/templates/data_document/data_document_detail.html
@@ -71,6 +71,7 @@
     {% endif %}
 
     <div class="col-sm-6">
+    {% if extracted_text_form %}
     <h4>Extracted Text</h4>
     <div class="card-body border">
         {% if extracted_text_form.errors %}
@@ -111,7 +112,8 @@
             <button type="submit" id="save_extracted_text" name="save_extracted_text"
                     class="btn btn-primary chem-control" role="button">Save edits</button>
         </form>
-    </div>
+        </div>
+        {% endif %}
     </div>
     </div>
 

--- a/templates/data_document/data_document_detail.html
+++ b/templates/data_document/data_document_detail.html
@@ -70,7 +70,7 @@
     </div>
     {% endif %}
 
-    <div class="col-sm-6">
+    <div class="col-sm-6 extracted-text">
     {% if extracted_text_form %}
     <h4>Extracted Text</h4>
     <div class="card-body border">
@@ -117,7 +117,7 @@
     </div>
     </div>
 
-
+{% if extracted_text_form %}
 <form method="post" action="">
     <div class="row col-sm-12">
         <h4>{{ doc.data_group.group_type }} detail</h4>
@@ -159,6 +159,7 @@
         </div>
     </div>
 </form>
+{% endif %}
 {% endblock %}
 <!-- if we need to be more specific with the way cards are layed out.....
 {%  if doc.data_group.is_chemical_presence %}


### PR DESCRIPTION
This branch satisfies the terms of ticket #470 : the data document detail page opens whether or not the data document has an associated ExtractedText object, and the test checkes every DataDocument object in the seed data.

There may be other cases where the code still expects an ExtractedText object and fails when one is absent, but I have not yet encountered them. The data group detail page, for example, loads fine. The QA pages are centered around the ExtractedText model rather than the DataDocument model.