### PR TITLE
502 Download raw comp data

### DIFF
--- a/dashboard/fixtures/06_datadocument.yaml
+++ b/dashboard/fixtures/06_datadocument.yaml
@@ -9,7 +9,7 @@
   fields: {created_at: !!timestamp '2018-03-09 11:32:00.391711', updated_at: !!timestamp '2018-10-16
       04:08:02.564253', filename: 11165872.pdf, title: Avgas 100LL (<0.1% Benzene),
     url: 'https://airbpmsds.bp.com/ussds/amersdsf.nsf/AllFiles_AIR_BP_FUELS/89C50579C812749A8025806F0057F0C0/$File/11165872.pdf',
-    raw_category: '', data_group: 6, matched: true, extracted: false, document_type: 2,
+    raw_category: '', data_group: 6, matched: true, extracted: true, document_type: 2,
     organization: ''}
 - model: dashboard.datadocument
   pk: 8

--- a/dashboard/tests/functional/test_datagroup_detail.py
+++ b/dashboard/tests/functional/test_datagroup_detail.py
@@ -186,3 +186,20 @@ class DataGroupDetailTest(TestCase):
                                          "User is redirected to detail page.")
         self.assertEqual(response.url, f'/datagroup/{dgpk}/',
                                          "Should go to detail page.")
+
+    def test_download_raw_comp_data(self):
+        # Ability to download, by data group, a csv file of raw extracted chemical composition data.
+
+        # Only applies for data group type Composition. (group_type = 2)
+        
+        response = self.client.get(f'/datagroup/6/')
+
+
+        # Download button would appear on data group detail page, 
+        # Download button would appear if any data documents have extracted text.
+
+        
+        # Download file would only include records which have extracted data.
+
+        # File downloaded must include [specified fields]
+

--- a/dashboard/tests/functional/test_datagroup_detail.py
+++ b/dashboard/tests/functional/test_datagroup_detail.py
@@ -195,25 +195,35 @@ class DataGroupDetailTestWithFixtures(TestCase):
 
     def test_download_raw_comp_data(self):
         # Ability to download, by data group, a csv file of raw extracted chemical composition data.
-
+        # Download button would appear on data group detail page, 
+        # Download button would appear if any data documents have extracted text.
         # Only applies for data group type Composition. (group_type = 2)
-        # Unidentified? 
-        # Try all data groups with ExtractedChemicals
+        # Unidentified is excluded as of issue #502
+        dg_co = DataGroup.objects.filter(group_type__code = 'CO').first()
+        resp = self.client.get(f'/datagroup/%s/' % dg_co.id)
+        print('Checking CO example /datagroup/%s/' % dg_co.id)
+        self.assertIn(b'Download Raw', resp.content)
+
+        dg_un = DataGroup.objects.filter(group_type__code = 'UN').first()
+        resp = self.client.get(f'/datagroup/%s/' % dg_un.id)
+        print('Checking UN example /datagroup/%s/' % dg_un.id)
+        self.assertNotIn(b'Download Raw', resp.content)
+        
+        # Test download on all data groups with ExtractedChemicals, whether
+        # they are CO or UN
         dg_ids = DataDocument.objects.filter(
             id__in=ExtractedChemical.objects.all().values('extracted_text_id')
             ).order_by().values_list('data_group_id',flat=True).distinct()
         
         for dg_id in dg_ids:
-            #response = self.client.get(f'/datagroup/%s/' % dg_id)
+            #resp = self.client.get(f'/datagroup/%s/' % dg_id)
             resp = self.client.get(f'/datagroup/raw_extracted_records/%s/' % dg_id)
             self.assertEqual(resp.status_code, 200)
-            #self.assertContains(resp.streaming_content.first(), 'extracted_text_id,id')
-
-        # Download button would appear on data group detail page, 
-        # Download button would appear if any data documents have extracted text.
-
-        
-        # Download file would only include records which have extracted data.
 
         # File downloaded must include [specified fields]
+        resp = self.client.get(f'/datagroup/raw_extracted_records/%s/' % dg_ids[0])
+        field_list = 'ExtractedChemical_id,raw_cas,raw_chem_name,raw_min_comp,raw_central_comp,raw_max_comp,unit_type'
+        content = list(i.decode('utf-8') for i in resp.streaming_content)
+        self.assertIn(field_list, content[1])
+            
 

--- a/dashboard/tests/functional/test_datagroup_detail.py
+++ b/dashboard/tests/functional/test_datagroup_detail.py
@@ -187,13 +187,27 @@ class DataGroupDetailTest(TestCase):
         self.assertEqual(response.url, f'/datagroup/{dgpk}/',
                                          "Should go to detail page.")
 
+class DataGroupDetailTestWithFixtures(TestCase):
+    fixtures = fixtures_standard
+
+    def setUp(self):
+        self.client.login(username='Karyn', password='specialP@55word')
+
     def test_download_raw_comp_data(self):
         # Ability to download, by data group, a csv file of raw extracted chemical composition data.
 
         # Only applies for data group type Composition. (group_type = 2)
+        # Unidentified? 
+        # Try all data groups with ExtractedChemicals
+        dg_ids = DataDocument.objects.filter(
+            id__in=ExtractedChemical.objects.all().values('extracted_text_id')
+            ).order_by().values_list('data_group_id',flat=True).distinct()
         
-        response = self.client.get(f'/datagroup/6/')
-
+        for dg_id in dg_ids:
+            #response = self.client.get(f'/datagroup/%s/' % dg_id)
+            resp = self.client.get(f'/datagroup/raw_extracted_records/%s/' % dg_id)
+            self.assertEqual(resp.status_code, 200)
+            #self.assertContains(resp.streaming_content.first(), 'extracted_text_id,id')
 
         # Download button would appear on data group detail page, 
         # Download button would appear if any data documents have extracted text.

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -23,6 +23,8 @@ urlpatterns = [
                                             name='dg_dd_csv_view'),
     path('datagroup/pdfs_zipped/<int:pk>/', views.dg_pdfs_zip_view,
                                             name='dg_pdfs_zip_view'),
+    path('datagroup/raw_extracted_records/<int:pk>/', views.dg_raw_extracted_records,
+                                            name='dg_raw_extracted_records'),
     path('datasource/<int:pk>/datagroup_new/', views.data_group_create,
                                             name='data_group_new'),
     path('datagroup/<int:pk>/registered_records.csv', views.data_group_registered_records_csv,

--- a/dashboard/views/data_group.py
+++ b/dashboard/views/data_group.py
@@ -42,7 +42,8 @@ def data_group_detail(request, pk,
     paginator = Paginator(docs, 50) # TODO: make this dynamic someday in its own ticket
     store = settings.MEDIA_URL + str(dg.fs_id)
     ext = ExtractedText.objects.filter(data_document_id__in=docs).first()
-    ext = ext.pull_out_cp()
+    if ext:
+        ext = ext.pull_out_cp()
     context = { 'datagroup'      : dg,
                 'documents'      : paginator.page(1 if page is None else page),
                 'all_documents'  : docs, # this used for template download
@@ -329,7 +330,7 @@ def habitsandpractices(request, pk,
 
 @login_required
 def dg_raw_extracted_records(request, pk):
-    columnlist = ['extracted_text_id','id','raw_cas','raw_chem_name','raw_min_comp','raw_central_comp','raw_max_comp','unit_type']
+    columnlist = ['extracted_text_id','id','raw_cas','raw_chem_name','raw_min_comp','raw_central_comp','raw_max_comp','unit_type__title']
     dg = DataGroup.objects.get(pk=pk)
     et = ExtractedText.objects.filter(data_document__data_group = dg).first()
     if et:

--- a/dashboard/views/data_group.py
+++ b/dashboard/views/data_group.py
@@ -41,8 +41,8 @@ def data_group_detail(request, pk,
     page = request.GET.get('page')
     paginator = Paginator(docs, 50) # TODO: make this dynamic someday in its own ticket
     store = settings.MEDIA_URL + str(dg.fs_id)
-    # TODO: test to see if this handles DoesNotExist
     ext = ExtractedText.objects.filter(data_document_id__in=docs).first()
+    ext = ext.pull_out_cp()
     context = { 'datagroup'      : dg,
                 'documents'      : paginator.page(1 if page is None else page),
                 'all_documents'  : docs, # this used for template download
@@ -326,3 +326,21 @@ def habitsandpractices(request, pk,
                       'hp_formset'  : hp_formset,
                       }
     return render(request, template_name, context)
+
+@login_required
+def dg_raw_extracted_records(request, pk):
+    columnlist = ['extracted_text_id','id','raw_cas','raw_chem_name','raw_min_comp','raw_central_comp','raw_max_comp','unit_type']
+    dg = DataGroup.objects.get(pk=pk)
+    et = ExtractedText.objects.filter(data_document__data_group = dg).first()
+    if et:
+        dg_name = dg.get_name_as_slug()
+        qs = ExtractedChemical.objects.filter(extracted_text__data_document__data_group_id=pk).values(*columnlist)
+        #print('Writing %s records to csv' % len(qs) )
+        return render_to_csv_response(qs, filename=(dg_name +
+                                                    "_raw_extracted_records.csv"),
+                                  field_header_map={"id": "ExtractedChemical_id"},
+                                  use_verbose_names=False)
+    else:
+        qs = ExtractedChemical.objects.filter(extracted_text__data_document__id=pk).values(*columnlist)
+        return render_to_csv_response(qs, filename='raw_extracted_records.csv' ,
+                                        use_verbose_names=False)

--- a/templates/data_group/datagroup_detail.html
+++ b/templates/data_group/datagroup_detail.html
@@ -93,7 +93,7 @@
               {% if datagroup.matched_docs == 0 %}disabled{% endif %}">
           <span class="oi oi-data-transfer-download"></span> Download All PDF Documents
         </a>
-        {% if datagroup.group_type.code in "CO,UN" %}
+        {% if datagroup.group_type.code in "CO" %}
         <a href="{% url 'dg_raw_extracted_records' datagroup.pk  %}" class="btn btn-secondary">
             <span class="oi oi-spreadsheet"></span>&nbsp;Download Raw {{ datagroup.group_type }} Records</a>
         {% endif %}

--- a/templates/data_group/datagroup_detail.html
+++ b/templates/data_group/datagroup_detail.html
@@ -93,6 +93,11 @@
               {% if datagroup.matched_docs == 0 %}disabled{% endif %}">
           <span class="oi oi-data-transfer-download"></span> Download All PDF Documents
         </a>
+        {% if datagroup.group_type.code in "CO,UN" %}
+        <a href="{% url 'dg_raw_extracted_records' datagroup.pk  %}" class="btn btn-secondary">
+            <span class="oi oi-spreadsheet"></span>&nbsp;Download Raw {{ datagroup.group_type }} Records</a>
+        {% endif %}
+
         <br><br>
         {% if extract_form %}
             <a class="btn btn-secondary" data-toggle="collapse" id="btn_extract_text_form" href="#extract_form">


### PR DESCRIPTION
There is a new button on the Data Group Detail page that allows users to download all the extracted raw records for a Composition data group.