### PR TITLE
509: Repair pdf link in Extracted Text QA page

### DIFF
--- a/templates/qa/extracted_text_qa.html
+++ b/templates/qa/extracted_text_qa.html
@@ -59,7 +59,7 @@
       <tr>
         <th>PDF</th>
         <td>
-          <a href="/media/{{ doc.data_group.get_dg_folder }}/pdf/{{ doc.get_abstract_filename }}"
+          <a href="{{ doc.pdf_url }}"
               title="Link to {{ doc.get_abstract_filename }}" target="_blank">{{ doc.get_abstract_filename }}</a>
           <small><i>click to open PDF in new window</i></small>
         </td>


### PR DESCRIPTION
The tag that generated the pdf link on the QA page was using obsolete code. It has been updated.