### PR TITLE
#521 Search results now include Product.upc field

### DIFF
--- a/dashboard/search_indexes.py
+++ b/dashboard/search_indexes.py
@@ -65,6 +65,7 @@ class ProductIndex(indexes.SearchIndex, indexes.Indexable):
     template_name='search/indexes/dashboard/product_text.txt')
     title = indexes.EdgeNgramField(model_attr='title')
     facet_model_name = indexes.CharField(faceted=True)
+    upc = indexes.CharField(model_attr='upc')
     result_css_class = indexes.CharField()
     short_description = indexes.EdgeNgramField(model_attr="short_description", null=True)
 

--- a/dashboard/tests/functional/test_faceted_search.py
+++ b/dashboard/tests/functional/test_faceted_search.py
@@ -19,6 +19,11 @@ class FacetedSearchTest(TestCase):
         self.assertNotContains(response, 'Extracted Chemical')
         self.assertNotContains(response, 'DSSTox Substance')
 
+    def test_faceted_search_returns_upc(self):
+        response = self.c.get('/find/?q=avcat')
+        self.assertContains(response, 'stub_1845')
+
+
     def test_group_type_facet(self):
         response = self.c.get('/find/?q=diatom')
         self.assertContains(response, 'Filter by Group Type')

--- a/templates/search/facet_search.html
+++ b/templates/search/facet_search.html
@@ -124,13 +124,14 @@
                 <thead class="table-primary">
                   <th>Type</th>
                   <th>Record</th>
+                  <th>UPC</th>
                   <th>PUC</th>
                   <th>Brand Name</th>
                 </thead>
                 <tbody>
                 {% for result in page_obj.object_list %}
                   <tr>
-                    <td>
+                    <td class="text-left">
                       <a class="btn
                       {% if result.facet_model_name == 'Product' %}
                       btn-success
@@ -141,11 +142,18 @@
                         href="{{ result.object.get_absolute_url }}">{{ result.facet_model_name }}</a>
 
                     </td>
-                    <td>
+                    <td class="text-left">
                       {{ result.object.title }}
                     </td>
 
-                    <td>
+                    </td>
+                    <td class="text-left">
+                    {% if result.upc %}
+                        {{ result.upc }}
+                    {% endif %}
+                    </td>
+
+                    <td class="text-left">
                       {% if result.pucs %}
                       <div style="border-style:solid;border-color:#{{ result.pucs.1 }};border-radius: 2px;">
                         {{ result.pucs.0 }}
@@ -153,7 +161,7 @@
                       {% endif %}
                     </td>
                     {% if  result.brand_name %}
-                    <td><b>{{ result.brand_name }}</b></td>
+                    <td class="text-left"><b>{{ result.brand_name }}</b></td>
                     {% else %}
                     <td></td>
                     {% endif %}

--- a/templates/search/indexes/dashboard/product_text.txt
+++ b/templates/search/indexes/dashboard/product_text.txt
@@ -1,2 +1,3 @@
 {{ object.title }}
 {{ object.get_uber_puc }}
+{{ object.upc }}


### PR DESCRIPTION
The elasticsearch index now includes the Product.upc field as its own column. We discussed changing the tabular format back to a series of divs, but as of commit e913058, the template still uses a table with a column for each returned field. 