### PR TITLE
verify prod_name is the same for every data_document

### DIFF
--- a/dashboard/tests/functional/test_extracted_text_upload.py
+++ b/dashboard/tests/functional/test_extracted_text_upload.py
@@ -14,9 +14,7 @@ from dashboard.models import *
 class UploadExtractedFileTest(TestCase):
     fixtures = ['00_superuser.yaml', '01_lookups.yaml',
                 '02_datasource.yaml', '03_datagroup.yaml', '04_PUC.yaml',
-                '05_product.yaml', '06_datadocument.yaml', '07_script.yaml',
-                '08_extractedtext.yaml', '09_productdocument.yaml', 
-                '10_extractedchemical', '11_dsstoxsubstance']
+                '05_product.yaml', '06_datadocument.yaml', '07_script.yaml']
 
     def setUp(self):
         self.c = Client()
@@ -24,7 +22,7 @@ class UploadExtractedFileTest(TestCase):
         self.c.login(username='Karyn', password='specialP@55word')
 
 
-    def generate_valid_chem_csv_string(self):
+    def generate_valid_chem_csv(self):
         csv_string = ("data_document_id,data_document_filename,"
                     "prod_name,doc_date,rev_num,raw_category,raw_cas,raw_chem_name,"
                     "report_funcuse,raw_min_comp,raw_max_comp,unit_type,"
@@ -36,33 +34,69 @@ class UploadExtractedFileTest(TestCase):
                     "7,11165872.pdf,Alberto European Hairspray (Aerosol) - All Variants,,,aerosol hairspray,"
                     "0000064-17-5,sd alcohol 40-b (ethanol),,0.5,0.55,1,,"
                     )
-        return csv_string
-
-    def test_chem_upload(self):
-        sample_csv = self.generate_valid_chem_csv_string()
-        sample_csv_bytes = sample_csv.encode(encoding='UTF-8',errors='strict' )
+        sample_csv_bytes = csv_string.encode(encoding='UTF-8',errors='strict' )
         in_mem_sample_csv = InMemoryUploadedFile(
                 io.BytesIO(sample_csv_bytes),
                 field_name='extract_file',
                 name='British_Petroleum_(Air)_1_extract_template.csv',
                 content_type='text/csv',
-                size=len(sample_csv),
-                charset='utf-8',
-        )
+                size=len(csv_string),
+                charset='utf-8')
+        return in_mem_sample_csv
+
+    def generate_invalid_chem_csv(self):
+        csv_string = ("data_document_id,data_document_filename,"
+                    "prod_name,doc_date,rev_num,raw_category,raw_cas,raw_chem_name,"
+                    "report_funcuse,raw_min_comp,raw_max_comp,unit_type,"
+                    "ingredient_rank,raw_central_comp"
+                    "\n"
+                    "8,11177849.pdf,Alberto European Hairspray (Aerosol) - All Variants,,,aerosol hairspray,"
+                    "0000075-37-6,hydrofluorocarbon 152a (difluoroethane),,0.39,0.42,1,,"
+                    "\n"
+                    "8,11177849.pdf,A different prod_name with the same datadocument,,,aerosol hairspray,"
+                    "0000064-17-5,sd alcohol 40-b (ethanol),,0.5,0.55,1,,"
+                    )
+        sample_csv_bytes = csv_string.encode(encoding='UTF-8',errors='strict' )
+        in_mem_sample_csv = InMemoryUploadedFile(
+                io.BytesIO(sample_csv_bytes),
+                field_name='extract_file',
+                name='British_Petroleum_(Air)_1_extract_template.csv',
+                content_type='text/csv',
+                size=len(csv_string),
+                charset='utf-8')
+        return in_mem_sample_csv
+
+    def test_chem_upload(self):
         req_data = {'script_selection': 5,
                     'weight_fraction_type': 1,
                     'extract_button': 'Submit',
                     }
 
         req = self.factory.post(path = '/datagroup/6/' , data=req_data)
-        req.FILES['extract_file'] = in_mem_sample_csv
         req.user = User.objects.get(username='Karyn')
-        # Now get the response
+        req.FILES['extract_file'] = self.generate_invalid_chem_csv()
+        # get error in response
+        resp = views.data_group_detail(request=req, pk=6)
+        # print(resp.content)
+        self.assertContains(resp,'must be 1:1')
+        text_count = ExtractedText.objects.all().count()
+        self.assertTrue(text_count < 2, 
+                                    'Shouldn\'t be 2 extracted texts uploaded')
+        # Now get the success response
+        req.FILES['extract_file'] = self.generate_valid_chem_csv()
+        doc_count = DataDocument.objects.filter(
+                                    raw_category='aerosol hairspray').count()
+        self.assertTrue(doc_count == 0, 
+                            'DataDocument raw category shouldn\'t exist yet.')
         resp = views.data_group_detail(request=req, pk=6)
         self.assertContains(resp,'2 extracted records uploaded successfully.')
 
-        doc_count = DataDocument.objects.filter(raw_category='aerosol hairspray').count()
-        self.assertTrue(doc_count > 0, 'DataDocument raw category values must be updated.')
+        doc_count = DataDocument.objects.filter(
+                                    raw_category='aerosol hairspray').count()
+        self.assertTrue(doc_count > 0, 
+                            'DataDocument raw category values must be updated.')
+        text_count = ExtractedText.objects.all().count()
+        self.assertTrue(text_count == 2, 'Should be 2 extracted texts')
         dg = DataGroup.objects.get(pk=6)
         dg.delete()
 

--- a/dashboard/views/data_group.py
+++ b/dashboard/views/data_group.py
@@ -111,6 +111,10 @@ def data_group_detail(request, pk,
                     row['ingredient_rank'] = None if rank == '' else rank
                 ext, created = ext_parent.objects.get_or_create(data_document=d,
                                                     extraction_script=script)
+                if not created and ext.prod_name != row['prod_name']:
+                    # check that there is a 1:1 relation w/ prod_name
+                    err_msg = ['must be 1:1 with "data_document_id".']
+                    context['ext_err'][i+1] = {'prod_name': err_msg}
                 if created:
                     update_fields(row, ext)
                 row['extracted_text'] = ext


### PR DESCRIPTION
this is the simplest way I could think of to check that each record for a given `data_document_id` has the same value for `prod_name`. The error was being thrown because there ended up being ~224 `ExtractedChemical` cards on the QA page, each card has something like 7 `<input>` fields and Django has a default setting of a max number of 1000. 

This seems to be a unique case w/ this group of datadocuments, but to resolve @kdionisio and I thought it would be best to make sure the `data_document_id` and `prod_name` fields are the same. The picture I attached to the issue might help illustrate.

I also added to an existing test that an error will be thrown in this event. A thing to note was that I removed the `08_extractedtext.yaml`. With that being loaded into the test I realized that the test wasn't created new `ExtractedText` objects, but updating existing.