### PR TITLE
579 Refine QA Group creation workflow

### DIFF
--- a/dashboard/models/qa_group.py
+++ b/dashboard/models/qa_group.py
@@ -1,10 +1,12 @@
 from django.db import models
 from .common_info import CommonInfo
-from .script import Script
 from .extracted_text import ExtractedText
 
 
+
+
 class QAGroup(CommonInfo):
+    from .script import Script
 
     extraction_script = models.ForeignKey(Script,
                                     on_delete=models.CASCADE,

--- a/dashboard/models/script.py
+++ b/dashboard/models/script.py
@@ -104,13 +104,14 @@ class Script(CommonInfo):
             texts = None
 
         # Set the qa_group attribute of each ExtractedText record to the new QA Group    
-        for text in texts:
-            text.qa_group = qa_group
-            text.save()
+        if texts is not None:
+            for text in texts:
+                text.qa_group = qa_group
+                text.save()
 
         # If the force_doc_id argument was populated, make sure it gets assigned 
         # to the new QA Group
-        if force_doc_id is not None and ExtractedText.objects.get(pk=force_doc_id).exists():
+        if force_doc_id is not None and ExtractedText.objects.filter(pk=force_doc_id).exists():
             text = ExtractedText.objects.get(pk=force_doc_id)
             text.qa_group = qa_group
             text.save()

--- a/dashboard/models/script.py
+++ b/dashboard/models/script.py
@@ -4,6 +4,8 @@ from django.core.validators import URLValidator
 
 from .common_info import CommonInfo
 from .data_document import DataDocument
+import math
+from random import shuffle
 
 
 class Script(CommonInfo):
@@ -63,3 +65,56 @@ class Script(CommonInfo):
         Return true when the percent checked is above the threshold
         """
         return self.get_pct_checked_numeric() >= QA_COMPLETE_PERCENTAGE * 100
+
+    def create_qa_group(self, force_doc_id=None):
+        """
+        Creates a QA Group for the specified Script object;
+        Use all the related ExtractedText records or, if there are more than 100,
+        select 20% of them. 
+        """
+        from .qa_group import QAGroup
+        from .extracted_text import ExtractedText
+        es = self
+        # Confirm that there's no existing QA Group for this Script
+        if QAGroup.objects.filter(extraction_script = es).count() >= 1:
+            print('QA Group already found for %s Script' % es )
+            return QAGroup.objects.get(extraction_script = es)
+        
+        # Create a new QA Group for the ExtractionScript es
+        qa_group = QAGroup.objects.create(extraction_script=es)
+        # Collect all the ExtractedText object keys that are related
+        # to the Script being QA'd and have not yet been checked
+        doc_text_ids = list(ExtractedText.objects.filter(extraction_script=es,
+                                                    qa_checked=False
+                                                    ).values_list('pk',
+                                                                flat=True))
+        # If there are fewer than 100 related records, they make up the entire QA Group
+        if len(doc_text_ids) < 100 and len(doc_text_ids) > 0:
+            texts = ExtractedText.objects.filter(pk__in=doc_text_ids)
+        # Otherwise sample 20 percent
+        elif len(doc_text_ids) >= 100 :
+            # Otherwise sample 20% of them
+            random_20 = math.ceil(len(doc_text_ids)/5)
+            shuffle(doc_text_ids)  # this is used to make random selection of texts
+            texts = ExtractedText.objects.filter(pk__in=doc_text_ids[:random_20])
+        else:
+            # If there are no related ExtractedText records, something has gone wrong
+            # Don't make a new QA Group with zero ExtractedTexts
+            print('The Script has no related ExtractedText records')
+            texts = None
+
+        # Set the qa_group attribute of each ExtractedText record to the new QA Group    
+        for text in texts:
+            text.qa_group = qa_group
+            text.save()
+
+        # If the force_doc_id argument was populated, make sure it gets assigned 
+        # to the new QA Group
+        if force_doc_id is not None and ExtractedText.objects.get(pk=force_doc_id).exists():
+            text = ExtractedText.objects.get(pk=force_doc_id)
+            text.qa_group = qa_group
+            text.save()
+        
+        return qa_group
+
+        

--- a/dashboard/tests/functional/test_qa_seed_data.py
+++ b/dashboard/tests/functional/test_qa_seed_data.py
@@ -21,6 +21,98 @@ class TestQaPage(TestCase):
         response = self.client.get('/qa/extractionscript/5/')
         self.assertTrue(Script.objects.get(pk=5).qa_begun,
                     'qa_begun should now be true')
+    
+    def test_new_qa_group_urls(self):
+        # Begin from the QA index page
+        response = self.client.get(f'/qa/')
+        self.assertIn(f"/qa/extractionscript/15/'> Begin QA".encode() , response.content)
+        # Script 15 has one ExtractedText object
+        pk = 15
+        response = self.client.get(f'/qa/extractionscript/{pk}/')
+        et = ExtractedText.objects.filter(extraction_script = pk).first()
+        self.assertIn(f'/qa/extractedtext/{et.pk}/'.encode() , response.content)
+        # After opening the URL, the following should be true:
+        # One new QA group should be created
+        group_count = QAGroup.objects.filter(extraction_script_id = pk).count()
+        self.assertTrue( group_count == 1)
+        # The ExtractionScript's qa_begun property should be set to True
+        self.assertTrue( Script.objects.get(pk=15).qa_begun )
+        # The ExtractedText object should be assigned to the QA Group
+        group_pk = QAGroup.objects.get(extraction_script_id = pk).pk
+        et = ExtractedText.objects.filter(extraction_script = pk).first()
+        self.assertTrue( et.qa_group_id == group_pk )
+        # The link on the QA index page should now say "Continue QA"
+        response = self.client.get(f'/qa/')
+        self.assertIn(f"'/qa/extractionscript/15/\'> Continue QA".encode() , response.content)
+
+
+    def test_qa_script_without_ext_text(self):
+        # Begin from the QA index page
+        response = self.client.get(f'/qa/')
+        self.assertIn(f"/qa/extractionscript/15/'> Begin QA".encode() , response.content)
+        # Script 9 has no ExtractedText objects
+        pk = 9
+        # a user will see no link on the QA index page, but it's still
+        # possible to enter the URL
+        response = self.client.get(f'/qa/extractionscript/{pk}/', follow=True)
+        self.assertEqual(response.status_code, 200)
+
+
+    def test_data_document_qa(self):
+        # Open the QA page for an ExtractedText record that has no QA group
+        # and is in a Script with < 100 documents
+        pk = ExtractedText.objects.filter( qa_group=None  ).first().pk
+        response = self.client.get(f'/datadocument/qa/extractedtext/{pk}/')
+        
+        # After opening the QA link from the data document detail page, the 
+        # following should be true:
+        # One new QA group should be created
+        scr = ExtractedText.objects.get(pk=pk).extraction_script
+
+        group_count = QAGroup.objects.filter(extraction_script = scr).count()
+        self.assertTrue( group_count == 1)
+        # The ExtractionScript's qa_begun property should be set to True
+        self.assertTrue( scr.qa_begun )
+        # The ExtractedText object should be assigned to the QA Group
+        new_group = QAGroup.objects.get(extraction_script = scr)
+        et = ExtractedText.objects.get(pk=pk)
+        self.assertTrue( et.qa_group == new_group )
+        # The link on the QA index page should now say "Continue QA"
+        response = self.client.get(f'/qa/')
+        self.assertIn(f"'/qa/extractionscript/{scr.pk}/\'> Continue QA".encode() , response.content)
+
+        # Open the QA page for an ExtractedText record that has no QA group and
+        # is related to a script with over 100 documents
+        pk = ExtractedText.objects.filter( extraction_script_id = 12  ).first().pk
+        response = self.client.get(f'/datadocument/qa/extractedtext/{pk}/')
+        scr = ExtractedText.objects.get(pk=pk).extraction_script
+        # After opening the QA link from the data document detail page, the 
+        # following should be true:
+        # One new QA group should be created
+        new_group = QAGroup.objects.get(extraction_script = scr)
+        
+        # There should be a lot of ExtractedText records assigned to the QA Group
+        initial_qa_count = ExtractedText.objects.filter(qa_group = new_group ).count()
+        self.assertTrue( initial_qa_count > 100 )
+        
+        # Select adocument that shares a Script with the
+        # QA Group created above BUT DOES NOT BELONG TO THE QA GROUP
+        pk = ExtractedText.objects.filter( extraction_script_id = 12).filter(qa_group = None ).first().pk
+        # Open its QA page via the /datdocument/qa path
+        response = self.client.get(f'/datadocument/qa/extractedtext/{pk}/')
+        # Make sure that the number of documents in the QA Group has increased
+        self.assertTrue(ExtractedText.objects.filter(qa_group = new_group ).count() > initial_qa_count )
+
+
+
+        
+       
+
+
+
+
+
+
 
     def test_approval(self):
         # Open the Script page to create a QA Group

--- a/dashboard/tests/integration/test_user_experience.py
+++ b/dashboard/tests/integration/test_user_experience.py
@@ -96,6 +96,8 @@ class TestIntegration(StaticLiveServerTestCase):
 
         num_pucs = len(PUC.objects.all())
         self.browser.get(self.live_server_url)
+        import time
+        time.sleep(3) #or however long you think it'll take you to scroll down to bubble chart
         bubbles = self.browser.find_elements_by_class_name('bubble')
         self.assertEqual(num_pucs, len(bubbles), ('There should be a circle'
                                                     'drawn for every PUC'))

--- a/templates/qa/qa_index.html
+++ b/templates/qa/qa_index.html
@@ -27,9 +27,11 @@ QA</h1>
         <td>{{ extraction_script.get_datadocument_count }}</td>
         <td>{{ extraction_script.get_pct_checked }}</td>
         <td>
+         {% if extraction_script.get_datadocument_count > 0 %}
           <a class="btn btn-info btn-sm" role="button" title="{{ extraction_script.qa_button_text }} on {{ extraction_script.title }}"
            href='{% url "extraction_script_qa" extraction_script.id %}'> {{ extraction_script.qa_button_text }}
          </a>
+         {% endif %}
         </td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
This ticket began as a bug fix when users noticed multiple QA Group records had been created for the same Script object. The presence of multiple QA Group records caused an error when users tried to open the QA page for a Script. 

In this branch, the creation of a QA Group is now handled by a method in the Script model. The QA Group can be created from either the Data Document Detail page (the "QA" link will create a QA group for the document's Extraction Script if one does not exist) or from the QA page (via the "Begin QA" button). 

If the user opens the Extracted Text object's QA page and it does not already belong to the QA group for its related Script, the Extracted Text object is assigned to the existing QA Group. 

The QA index page no longer shows a link to the Script's QA page if the script has no associated ExtractedText objects. Manually entering the QA URL for a script with no ExtractedText records will redirect to the QA index page. This will prevent the creation of empty QA groups.

Please help think through if I have covered all the contingencies.


