### PR TITLE
532: Extracted Text QA page now links to its Data Document Detail page

### DIFF
--- a/dashboard/tests/functional/test_qa_seed_data.py
+++ b/dashboard/tests/functional/test_qa_seed_data.py
@@ -22,6 +22,11 @@ class TestQaPage(TestCase):
         self.assertTrue(Script.objects.get(pk=5).qa_begun,
                     'qa_begun should now be true')
 
+    def test_dd_link(self):
+        # Open the Script page to create a QA Group
+        response = self.client.get('/qa/extractedtext/5', follow=True)
+        self.assertIn(b'/datadocument/5', response.content)
+
     def test_approval(self):
         # Open the Script page to create a QA Group
         response = self.client.get('/qa/extractionscript/5', follow=True)

--- a/templates/qa/extracted_text_qa.html
+++ b/templates/qa/extracted_text_qa.html
@@ -26,7 +26,9 @@
   </nav>
 
   <div class="card">
-    <h3 class="card-header text-center">DataDocument: {{ doc.title }}</h3>
+    <h3 class="card-header text-center">
+            <a  href="{% url "data_document" doc.pk %}" target="_blank" title='Data Document Detail Page'>DataDocument: {{ doc.title }}</a>
+    </h3>
     <table class="table table-bordered">
 
       <tr>


### PR DESCRIPTION
Quick ticket: added a link to the QA detail page, wrote a test to make sure it's there.