### PR TITLE
#530 Changes to the naming of products during bulk creation, heavy-duty testing

### DIFF
--- a/dashboard/fixtures/03_datagroup.yaml
+++ b/dashboard/fixtures/03_datagroup.yaml
@@ -47,7 +47,7 @@
       12:16:49.057216', name: Walmart MSDS 3, description: '', downloaded_by: 1, downloaded_at: !!timestamp '2017-10-21
       08:47:08', download_script: null, data_source: 10, fs_id: e6d5926b-f05a-4e12-a7d8-a8db9d495c32,
     csv: Walmart_MSDS_3/Walmart_MSDS_3_out_10.csv, zip_file: media/Walmart_MSDS_3/Walmart_MSDS_3.zip,
-    group_type: 1, url: ''}
+    group_type: 2, url: ''}
 - model: dashboard.datagroup
   pk: 20
   fields: {created_at: !!timestamp '2018-05-11 07:00:37.681930', updated_at: !!timestamp '2018-06-20

--- a/dashboard/fixtures/06_datadocument.yaml
+++ b/dashboard/fixtures/06_datadocument.yaml
@@ -16,7 +16,7 @@
   fields: {created_at: !!timestamp '2018-03-09 11:32:00.392831', updated_at: !!timestamp '2018-10-14
       00:02:30.509335', filename: 11177849.pdf, title: AVCAT (FSII + Lubricity Improver
       Additive), url: 'https://airbpmsds.bp.com/ussds/amersdsf.nsf/AllFiles_AIR_BP_FUELS/A419F6F11DA742518025808E0057F2DB/$File/11177849.pdf',
-    raw_category: '', data_group: 6, matched: true, extracted: false, document_type: 5,
+    raw_category: '', data_group: 6, matched: true, extracted: true, document_type: 5,
     organization: ''}
 - model: dashboard.datadocument
   pk: 53

--- a/dashboard/fixtures/08_extractedtext.yaml
+++ b/dashboard/fixtures/08_extractedtext.yaml
@@ -2828,7 +2828,7 @@
 - model: dashboard.extractedtext
   pk: 141892
   fields: {created_at: !!timestamp '2018-06-06 07:19:07', updated_at: !!timestamp '2018-06-06
-      07:19:07', prod_name: null, doc_date: null, rev_num: null,
+      07:19:07', prod_name: 'SSC Dark & Natural Hair Color Kit', doc_date: null, rev_num: null,
     extraction_script: 12, qa_checked: false, qa_edited: false, qa_approved_date: null,
     qa_approved_by: null, qa_group: null}
 - model: dashboard.extractedtext

--- a/dashboard/models/product_document.py
+++ b/dashboard/models/product_document.py
@@ -11,7 +11,7 @@ class ProductDocument(CommonInfo):
 	document = models.ForeignKey(DataDocument, on_delete=models.CASCADE)
 
 	def __str__(self):
-		return self.product.title
+		return '%s --> %s' % (self.product.title, self.document.title)
 
 	def get_absolute_url(self):
 		return reverse('product_detail', kwargs={'pk': self.pk})

--- a/dashboard/tests/functional/test_datagroup_detail.py
+++ b/dashboard/tests/functional/test_datagroup_detail.py
@@ -112,17 +112,18 @@ class DataGroupDetailTest(TestCase):
 
     def test_bulk_create_post(self):
         '''test the POST to create Products and link if needed'''
+        # create a new DataDocument with no Product
         doc = DataDocument.objects.create(data_group=self.objects.dg)
         response = self.client.get(f'/datagroup/{self.objects.dg.pk}/')
         self.assertEqual(response.context['bulk'], 1,
                 'Not all DataDocuments linked to Product, bulk_create needed')
         response = self.client.post(f'/datagroup/{self.objects.dg.pk}/',
-                                                                {'bulk':47})
+                                                                {'bulk':1})
         self.assertEqual(response.context['bulk'], 0,
-                'Product linked to all DataDocuments, no bulk_create needed.')
+                'Products linked to all DataDocuments, no bulk_create needed.')
         product = ProductDocument.objects.get(document=doc).product
         self.assertEqual(product.title, 'unknown',
-                                        'Title should be unkown in bulk_create')
+                                        'Title should be unknown in bulk_create')
         self.assertEqual(product.upc, 'stub_2',
                                     'UPC should be created for second Product')
 

--- a/dashboard/tests/functional/test_product_linkage.py
+++ b/dashboard/tests/functional/test_product_linkage.py
@@ -48,3 +48,52 @@ class TestProductLinkage(TestCase):
 
         self.assertFalse(response_html.xpath('string(//*[@id="id_document_type"]/option[@value="6"])'),
                       'Document_type_id 6 should NOT be an option when the datagroup type is composition.')
+
+    def test_bulk_create_products(self):
+        # DataGroup 19 is a Composition dg with unlinked products
+        dg = DataGroup.objects.get(pk=19)
+        response = self.client.get(f'/datagroup/19/')
+        self.assertEqual(response.context['bulk'], 75,
+                'Not all DataDocuments linked to Product, bulk_create needed')
+        response = self.client.post(f'/datagroup/19/',{'bulk':75})
+        self.assertEqual(response.context['bulk'], 0,
+                'Product linked to all DataDocuments, no bulk_create needed.')
+        # pick documents and check the attributes of their now-related products
+        # 1: check a case where the ExtractedText record had a prod_name to offer
+        ets = ExtractedText.objects.filter(data_document__data_group=dg)
+        et = ets.filter(prod_name__isnull=False).first()
+        doc = DataDocument.objects.get(pk=et.data_document_id)
+        product = ProductDocument.objects.get(document=doc).product
+        self.assertEqual(product.title, et.prod_name,
+                                        'Title should be taken from ExtractedText.prod_name in bulk_create')
+        # 2: check a case where ExtractedText.prod_name is None
+        et = ets.filter(prod_name__isnull=True).first()
+        doc = DataDocument.objects.get(pk=et.data_document_id)
+        product = ProductDocument.objects.get(document=doc).product
+        self.assertEqual(product.title, '%s stub' % doc.title ,
+                                        ('Title should be taken from the DataDocument.title in bulk_create,'
+                                        'with "stub" appended') )
+        # 3: check a case where the ExtractedText doesn't exist
+        # Data Group 6 has 2 docs that are linked to Product and ExtractedText records
+        #docs = DataDocument.objects.filter(data_group__group_type__title='Composition').exclude(extracted=True)
+        dg = DataGroup.objects.get(pk=6)
+        docs = DataDocument.objects.filter(data_group=dg)
+        doc_list = docs.values_list('id')
+        # delete the ExtractedText links and recreate them via the bulk request
+        ExtractedText.objects.filter(data_document_id__in=doc_list).delete()
+        # delete the ProductDocument links and recreate them via the bulk request
+        ProductDocument.objects.filter(document_id__in=doc_list).delete()
+        response = self.client.get(f'/datagroup/6/')
+        self.assertEqual(response.context['bulk'], 2,
+                'Not all DataDocuments linked to Product, bulk_create needed')
+        response = self.client.post(f'/datagroup/6/',{'bulk':1})
+        self.assertEqual(response.context['bulk'], 0,
+                'Product linked to all DataDocuments, no bulk_create needed.')
+        # check the titles of the newly-created products
+        # they should be based on the document title
+        doc = docs.first()
+        prod = Product.objects.filter(documents__in=[doc]).first()
+        self.assertEqual('%s stub' % doc.title, prod.title,
+                'Product and DataDocument titles should be the same.')
+        
+

--- a/dashboard/views/data_group.py
+++ b/dashboard/views/data_group.py
@@ -147,22 +147,14 @@ def data_group_detail(request, pk,
         stub = Product.objects.all().count() + 1
         for doc in docs_needing_products:
             # Try to name the new product from the ExtractedText record's prod_name
-            try:
-                ext = ExtractedText.objects.get(data_document_id=doc.id)
-                if ext:
-                    ext = ext.pull_out_cp()
-                    if ext.prod_name:
-                        new_prod_title = ext.prod_name
-                    else:
-                        new_prod_title = None
-            except ExtractedText.DoesNotExist:
-                new_prod_title = None
-            # If the ExtractedText record can't provide a title, use the DataDocument's title
-            if not new_prod_title:
-                if doc.title:
-                    new_prod_title = '%s stub' % doc.title
-                else:
-                    new_prod_title = 'unknown'
+
+            if doc.extracted and doc.extractedtext.prod_name:
+                new_prod_title = doc.extractedtext.prod_name
+            elif doc.title:
+                new_prod_title = '%s stub' % doc.title
+            else:
+                new_prod_title = 'unknown'
+
             product = Product.objects.create(
                                     title=new_prod_title,
                                     upc=f'stub_{stub}',


### PR DESCRIPTION
Change "Walmart MSDS 3" data group in seed data to Composition type; correct"extracted" status for a data document in data group 6; add a prod_name to an extractedtext record for testing; enhance str output of ProductDocument object; update existing loader-only bulk creation test; add extensive tests for bulk creation with seed data