### PR TITLE
add extra child form, test

### DIFF
--- a/dashboard/forms.py
+++ b/dashboard/forms.py
@@ -238,7 +238,7 @@ def include_clean_comp_data_form(dg):
 
 
 
-def create_detail_formset(group_type, extra=0, can_delete=False):
+def create_detail_formset(group_type, extra=1, can_delete=False):
     '''Returns the pair of formsets that will be needed based on group_type.
     .                       ('CO'),('CP'),('FU'),('HP')
     .

--- a/dashboard/tests/functional/test_qa_seed_data.py
+++ b/dashboard/tests/functional/test_qa_seed_data.py
@@ -103,16 +103,10 @@ class TestQaPage(TestCase):
         # Make sure that the number of documents in the QA Group has increased
         self.assertTrue(ExtractedText.objects.filter(qa_group = new_group ).count() > initial_qa_count )
 
-
-
-        
-       
-
-
-
-
-
-
+    def test_habitsandpractices(self):
+        # Begin from the QA index page
+        response = self.client.get(f'/habitsandpractices/54/')
+        self.assertContains(response, '<b>Add New Habit and Practice</b>')
 
     def test_dd_link(self):
         # Open the Script page to create a QA Group


### PR DESCRIPTION
this is a 1 character bug fix!

the child inline formset will now default to 1 extra form which was originally the case, but when we had added this to the datadocument detail view, we had not wanted to add the extra form, no longer the case.

there are 2 errors in the tests which I think have already been resolved, but are not merged to `dev` yet from wilson's ticket