### PR TITLE
#591 remove weight fraction type from QA view

### DIFF
--- a/dashboard/forms.py
+++ b/dashboard/forms.py
@@ -316,7 +316,7 @@ def include_clean_comp_data_form(dg):
         return False
 
 
-def create_detail_formset(document, extra=1, can_delete=False, exclude=None):
+def create_detail_formset(document, extra=1, can_delete=False, exclude=[]):
     '''Returns the pair of formsets that will be needed based on group_type.
     .                       ('CO'),('CP'),('FU'),('HP'),('HH')
     Parameters

--- a/dashboard/forms.py
+++ b/dashboard/forms.py
@@ -12,12 +12,12 @@ from dashboard.utils import get_extracted_models
 
 
 class DataGroupForm(forms.ModelForm):
-    required_css_class = 'required' # adds to label tag
+    required_css_class = 'required'  # adds to label tag
 
     class Meta:
         model = DataGroup
-        fields = ['name','description','url','group_type','downloaded_by',
-                    'downloaded_at','download_script','data_source','csv']
+        fields = ['name', 'description', 'url', 'group_type', 'downloaded_by',
+                  'downloaded_at', 'download_script', 'data_source', 'csv']
         widgets = {'downloaded_at': DatePickerInput()}
         labels = {'csv': _('Register Records CSV File'),
                   'url': _('URL'), }
@@ -26,19 +26,19 @@ class DataGroupForm(forms.ModelForm):
         qs = Script.objects.filter(script_type='DL')
         self.user = kwargs.pop('user', None)
         super(DataGroupForm, self).__init__(*args, **kwargs)
-        self.fields['csv'].widget.attrs.update({'accept':'.csv'})
+        self.fields['csv'].widget.attrs.update({'accept': '.csv'})
         self.fields['download_script'].queryset = qs
 
 
 class ExtractionScriptForm(forms.Form):
-    required_css_class = 'required' # adds to label tag
+    required_css_class = 'required'  # adds to label tag
     script_selection = forms.ModelChoiceField(
-                            queryset=Script.objects.filter(script_type='EX'),
-                            label="Extraction Script")
+        queryset=Script.objects.filter(script_type='EX'),
+        label="Extraction Script")
     weight_fraction_type = forms.ModelChoiceField(
-                            queryset=WeightFractionType.objects.all(),
-                            label="Weight Fraction Type",
-                            initial="1")
+        queryset=WeightFractionType.objects.all(),
+        label="Weight Fraction Type",
+        initial="1")
     extract_file = forms.FileField(label="Extracted Text CSV File")
 
     def __init__(self, *args, **kwargs):
@@ -46,34 +46,36 @@ class ExtractionScriptForm(forms.Form):
         self.user = kwargs.pop('user', None)
         super(ExtractionScriptForm, self).__init__(*args, **kwargs)
         self.fields['weight_fraction_type'].widget.attrs.update(
-                                        {'style':'height:2.75rem; !important'})
+            {'style': 'height:2.75rem; !important'})
         self.fields['script_selection'].widget.attrs.update(
-                                        {'style':'height:2.75rem; !important'})
-        self.fields['extract_file'].widget.attrs.update({'accept':'.csv'})
-        if self.dg_type in ['FU','CP']:
+            {'style': 'height:2.75rem; !important'})
+        self.fields['extract_file'].widget.attrs.update({'accept': '.csv'})
+        if self.dg_type in ['FU', 'CP']:
             del self.fields['weight_fraction_type']
         self.collapsed = True
 
 
 class CleanCompDataForm(forms.Form):
-    required_css_class = 'required' # adds to label tag
+    required_css_class = 'required'  # adds to label tag
     script_selection = forms.ModelChoiceField(
-                            queryset=Script.objects.filter(script_type='DC'),
-                            label="Data Cleaning Script",
-                            required=True)
+        queryset=Script.objects.filter(script_type='DC'),
+        label="Data Cleaning Script",
+        required=True)
     clean_comp_data_file = forms.FileField(label="Clean Composition Data CSV File",
-                            required=True)
+                                           required=True)
 
     def __init__(self, *args, **kwargs):
         super(CleanCompDataForm, self).__init__(*args, **kwargs)
         self.fields['script_selection'].widget.attrs.update(
-                                        {'style':'height:2.75rem; !important'})
-        self.fields['clean_comp_data_file'].widget.attrs.update({'accept':'.csv'})
+            {'style': 'height:2.75rem; !important'})
+        self.fields['clean_comp_data_file'].widget.attrs.update(
+            {'accept': '.csv'})
         self.collapsed = True
 
 
 class DataSourceForm(forms.ModelForm):
     required_css_class = 'required'
+
     class Meta:
         model = DataSource
         fields = ['title', 'url', 'estimated_records', 'state', 'priority',
@@ -90,7 +92,7 @@ class PriorityForm(forms.ModelForm):
         self.fields['priority'].label = ''
         self.fields['priority'].widget.attrs.update({
             'onchange': 'form.submit();'
-            })
+        })
 
 
 class QANotesForm(forms.ModelForm):
@@ -98,7 +100,7 @@ class QANotesForm(forms.ModelForm):
         model = QANotes
         fields = ['qa_notes']
         widgets = {
-            'qa_notes' : forms.Textarea,
+            'qa_notes': forms.Textarea,
         }
         labels = {
             'qa_notes': _('QA Notes (required if approving edited records)'),
@@ -114,7 +116,7 @@ class ExtractedTextQAForm(forms.ModelForm):
 
 
 class ProductLinkForm(forms.ModelForm):
-    required_css_class = 'required' # adds to label tag
+    required_css_class = 'required'  # adds to label tag
     document_type = forms.ModelChoiceField(
         queryset=DocumentType.objects.all(),
         label="Data Document Type",
@@ -123,7 +125,8 @@ class ProductLinkForm(forms.ModelForm):
 
     class Meta:
         model = Product
-        fields = ['title', 'manufacturer', 'brand_name', 'upc', 'size', 'color']
+        fields = ['title', 'manufacturer',
+                  'brand_name', 'upc', 'size', 'color']
 
     def __init__(self, *args, **kwargs):
         super(ProductLinkForm, self).__init__(*args, **kwargs)
@@ -155,7 +158,7 @@ class BasePUCForm(forms.ModelForm):
         label='Category',
         widget=autocomplete.ModelSelect2(
             url='puc-autocomplete',
-            attrs={'data-minimum-input-length': 3,})
+            attrs={'data-minimum-input-length': 3, })
     )
 
 
@@ -180,18 +183,21 @@ class BulkProductPUCForm(forms.ModelForm):
         model = ProductToPUC
         fields = ['puc', 'id_pks']
 
+
 class BulkPUCForm(BasePUCForm):
     class Meta:
         model = ProductToPUC
         fields = ['puc']
+
     def __init__(self, *args, **kwargs):
         super(BulkPUCForm, self).__init__(*args, **kwargs)
         lbl = 'Select PUC for Attribute to Assign to Selected Products'
         self.fields['puc'].label = lbl
         self.fields['puc'].widget.attrs['onchange'] = 'form.submit();'
 
+
 class BulkProductTagForm(forms.ModelForm):
-    required_css_class = 'required' # adds to label tag
+    required_css_class = 'required'  # adds to label tag
     tag = forms.ModelChoiceField(queryset=PUCTag.objects.none(),
                                  label='Attribute')
     id_pks = forms.CharField(label='Product Titles',
@@ -200,6 +206,7 @@ class BulkProductTagForm(forms.ModelForm):
     class Meta:
         model = ProductToPUC
         fields = ['tag', 'id_pks']
+
     def __init__(self, *args, **kwargs):
         super(BulkProductTagForm, self).__init__(*args, **kwargs)
         lbl = 'Select Attribute to Assign to Selected Products'
@@ -221,26 +228,30 @@ class ExtractedCPCatForm(ExtractedTextForm):
 
     class Meta:
         model = ExtractedCPCat
-        fields = ['doc_date','cat_code', 'description_cpcat','cpcat_sourcetype']
+        fields = ['doc_date', 'cat_code',
+                  'description_cpcat', 'cpcat_sourcetype']
+
 
 class ExtractedCPCatEditForm(ExtractedCPCatForm):
 
     class Meta(ExtractedCPCatForm.Meta):
-        fields = ExtractedCPCatForm.Meta.fields + ['prod_name','doc_date','rev_num','cpcat_code']
+        fields = ExtractedCPCatForm.Meta.fields + \
+            ['prod_name', 'doc_date', 'rev_num', 'cpcat_code']
 
 
 class ExtractedHHDocForm(ExtractedTextForm):
 
     class Meta:
         model = ExtractedHHDoc
-        fields = ['hhe_report_number','study_location', 'naics_code','sampling_date','population_gender',
-        'population_age','population_other','occupation','facility']
+        fields = ['hhe_report_number', 'study_location', 'naics_code', 'sampling_date', 'population_gender',
+                  'population_age', 'population_other', 'occupation', 'facility']
+
 
 class ExtractedHHDocEditForm(ExtractedHHDocForm):
 
     class Meta(ExtractedHHDocForm.Meta):
-        fields = ExtractedHHDocForm.Meta.fields + ['prod_name','doc_date','rev_num']
-
+        fields = ExtractedHHDocForm.Meta.fields + \
+            ['prod_name', 'doc_date', 'rev_num']
 
 
 class DocumentTypeForm(forms.ModelForm):
@@ -260,7 +271,7 @@ def include_extract_form(dg):
     '''Returns the ExtractionScriptForm based on conditions of DataGroup
     type as well as whether all records are matched, but not extracted
     '''
-    if not dg.type in ['FU','CO','CP']:
+    if not dg.type in ['FU', 'CO', 'CP']:
         return False
     if dg.all_matched() and not dg.all_extracted():
         return ExtractionScriptForm(dg_type=dg.type)
@@ -305,54 +316,68 @@ def include_clean_comp_data_form(dg):
         return False
 
 
-def create_detail_formset(document, extra=1, can_delete=True):
+def create_detail_formset(document, extra=1, can_delete=False, exclude=None):
     '''Returns the pair of formsets that will be needed based on group_type.
     .                       ('CO'),('CP'),('FU'),('HP'),('HH')
+    Parameters
+        ----------
+        document : DataDocument
+            The parent DataDocument
+        extra : integer
+            How many empty forms should be created for new records
+        can_delete : boolean
+            whether a delete checkbox is included
+        exclude : list
+            which fields to leave out of the form
     .
 
     '''
     group_type = document.data_group.type
     parent, child = get_extracted_models(group_type)
-    extracted = hasattr(document,'extractedtext')
+    extracted = hasattr(document, 'extractedtext')
 
-    def make_formset(parent_model,model,
-                        formset=BaseInlineFormSet, 
-                        form=forms.ModelForm):
-
+    def make_formset(parent_model, model,
+                     formset=BaseInlineFormSet,
+                     form=forms.ModelForm,
+                     exclude=exclude):
+        if exclude:
+            formset_fields = list(set(model.detail_fields()) - set(exclude))
+        else:
+            formset_fields = model.detail_fields()
         return forms.inlineformset_factory(parent_model=parent_model,
-                                            model=model,
-                                            fields=model.detail_fields(),
-                                            formset=formset, #this specifies a custom formset
-                                            form=form,
-                                            extra=extra,
-                                            can_delete=can_delete)
+                                           model=model,
+                                           fields=formset_fields,
+                                           formset=formset,  # this specifies a custom formset
+                                           form=form,
+                                           extra=extra,
+                                           can_delete=can_delete)
 
-    def one(): # for chemicals or unknown
+    def one():  # for chemicals or unknown
         ChemicalFormSet = make_formset(
             parent_model=parent,
             model=child,
             formset=ExtractedChemicalFormSet,
             form=ExtractedChemicalForm
-            )
+        )
         return (ExtractedTextForm, ChemicalFormSet)
 
-    def two(): # for functional_use
-        FunctionalUseFormSet = make_formset(parent,child)
+    def two():  # for functional_use
+        FunctionalUseFormSet = make_formset(parent, child)
         return (ExtractedTextForm, FunctionalUseFormSet)
 
-    def three(): # for habits_and_practices
-        HnPFormSet = make_formset(parent,child)
+    def three():  # for habits_and_practices
+        HnPFormSet = make_formset(parent, child)
         return (ExtractedTextForm, HnPFormSet)
 
-    def four(): # for extracted_list_presence
-        ListPresenceFormSet = make_formset(parent,child)
+    def four():  # for extracted_list_presence
+        ListPresenceFormSet = make_formset(parent, child)
         ParentForm = ExtractedCPCatForm if extracted else ExtractedCPCatEditForm
         return (ParentForm, ListPresenceFormSet)
 
-    def five(): # for extracted_hh_rec
-        HHFormSet = make_formset(parent,child)
+    def five():  # for extracted_hh_rec
+        HHFormSet = make_formset(parent, child)
         ParentForm = ExtractedHHDocForm if extracted else ExtractedHHDocEditForm
-        return (ParentForm , HHFormSet)
+        return (ParentForm, HHFormSet)
     dg_types = {
         'CO': one,
         'UN': one,
@@ -363,4 +388,3 @@ def create_detail_formset(document, extra=1, can_delete=True):
     }
     func = dg_types.get(group_type, lambda: None)
     return func()
-

--- a/dashboard/tests/integration/test_user_experience.py
+++ b/dashboard/tests/integration/test_user_experience.py
@@ -15,6 +15,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.common.exceptions import NoSuchElementException
 from django.conf import settings
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from dashboard.models import *
@@ -123,3 +124,19 @@ class TestIntegration(StaticLiveServerTestCase):
         tag = self.browser.find_element_by_class_name('taggit-tag')
         tag.click()
         self.assertTrue(submit.is_enabled(), "Button should be enabled")
+
+    def test_field_exclusion(self):
+        doc = self.objects.doc
+        # The element should not appear on the QA page
+        qa_url = self.live_server_url + f'/qa/{doc.pk}/'
+        self.browser.get(qa_url)
+        with self.assertRaises(NoSuchElementException):
+            self.browser.find_element_by_xpath('//*[@id="id_rawchem-0-weight_fraction_type"]')
+        # The element should appear on the datadocument page
+        dd_url = self.live_server_url + f'/datadocument/{doc.pk}/'
+        self.browser.get(dd_url)
+        try:
+            self.browser.find_element_by_xpath('//*[@id="id_rawchem-0-weight_fraction_type"]')
+        except NoSuchElementException:
+            self.fail("Absence of weight_fraction_type element raised exception")
+

--- a/dashboard/views/extraction_script.py
+++ b/dashboard/views/extraction_script.py
@@ -171,7 +171,8 @@ def extracted_text_qa(request, pk,
                 # rebuild the formset after saving it
                 detail_formset = ChildForm(instance=extext)
             else:
-                print(detail_formset.errors)
+                pass
+                # print(detail_formset.errors)
                 # TODO: iterate through this dict of errors and map each error to
                 # the corresponding form in the template for rendering
 

--- a/dashboard/views/extraction_script.py
+++ b/dashboard/views/extraction_script.py
@@ -16,10 +16,11 @@ from factotum.settings import EXTRA
 from dashboard.models import *
 from dashboard.utils import get_extracted_models
 from dashboard.forms import (ExtractedTextForm,
-                            create_detail_formset,   QANotesForm)
+                             create_detail_formset,   QANotesForm)
 
 
-from factotum.settings import EXTRA # if this goes to 0, tests will fail because of what num form we search for
+# if this goes to 0, tests will fail because of what num form we search for
+from factotum.settings import EXTRA
 
 
 @login_required()
@@ -43,38 +44,38 @@ def extraction_script_qa(request, pk,
     """
     es = get_object_or_404(Script, pk=pk)
     # If the Script has no related ExtractedText objects, redirect back to the QA index
-    if ExtractedText.objects.filter(extraction_script = es).count() == 0 :
+    if ExtractedText.objects.filter(extraction_script=es).count() == 0:
         return redirect('/qa/')
     # Check whether QA has begun for the script
     if es.qa_begun:
         # if the QA process has begun, there should already be one QA Group
-        # associated with the Script. 
+        # associated with the Script.
         try:
             # get the QA Group
             qa_group = QAGroup.objects.get(extraction_script=es,
-                                        qa_complete=False)
+                                           qa_complete=False)
         except MultipleObjectsReturned:
             qa_group = QAGroup.objects.filter(extraction_script=es,
-                                        qa_complete=False).first()
+                                              qa_complete=False).first()
         except ObjectDoesNotExist:
             print('No QA Group was found matching Extraction Script %s' % es.pk)
-        
 
         texts = ExtractedText.objects.filter(qa_group=qa_group,
-                                                qa_checked=False)        
+                                             qa_checked=False)
         return render(request, template_name, {'extractionscript': es,
-                                                'extractedtexts': texts,
-                                                'qagroup': qa_group})
+                                               'extractedtexts': texts,
+                                               'qagroup': qa_group})
     else:
-        qa_group = es.create_qa_group() 
-        es.qa_begun = True  
+        qa_group = es.create_qa_group()
+        es.qa_begun = True
         es.save()
     # Collect all the ExtractedText objects in the QA Group
     texts = ExtractedText.objects.filter(qa_group=qa_group)
-    
+
     return render(request, template_name, {'extractionscript': es,
                                            'extractedtexts': texts,
                                            'qagroup': qa_group})
+
 
 @login_required()
 def extraction_script_detail(request, pk,
@@ -87,7 +88,7 @@ def extraction_script_detail(request, pk,
 
 @login_required()
 def extracted_text_qa(request, pk,
-                            template_name='qa/extracted_text_qa.html', nextid=0):
+                      template_name='qa/extracted_text_qa.html', nextid=0):
     """
     Detailed view of an ExtractedText object, where the user can approve the
     record, edit its ExtractedChemical objects, skip to the next ExtractedText
@@ -99,10 +100,10 @@ def extracted_text_qa(request, pk,
     exscript = extext.extraction_script
     # when not coming from extraction_script page, we don't necessarily have a qa_group created
     if not extext.qa_group:
-        # create the qa group with the optional ExtractedText pk argument 
+        # create the qa group with the optional ExtractedText pk argument
         # so that the ExtractedText gets added to the QA group even if the
         # group uses a random sample
-        qa_group = exscript.create_qa_group( pk)
+        qa_group = exscript.create_qa_group(pk)
         exscript.qa_begun = True
         exscript.save()
         extext.qa_group = qa_group
@@ -123,8 +124,9 @@ def extracted_text_qa(request, pk,
     # Create the formset factory for the extracted records
     # The model used for the formset depends on whether the
     # extracted text object matches a data document()
-    
-    ParentForm, ChildForm = create_detail_formset(doc, EXTRA)
+    # The QA view should exclude the weight_fraction_type field.
+    ParentForm, ChildForm = create_detail_formset(
+        doc, EXTRA, can_delete=True, exclude=['weight_fraction_type'])
     # extext = extext.pull_out_cp()
     ext_form = ParentForm(instance=extext)
     detail_formset = ChildForm(instance=extext)
@@ -133,10 +135,10 @@ def extracted_text_qa(request, pk,
         for field in form.fields:
             form.fields[field].widget.attrs.update(
                 {'class': f'detail-control form-control %s' % doc.data_group.type}
-                )
+            )
 
     note, created = QANotes.objects.get_or_create(extracted_text=extext)
-    notesform =  QANotesForm(instance=note)
+    notesform = QANotesForm(instance=note)
 
     context = {
         'extracted_text': extext,
@@ -148,12 +150,12 @@ def extracted_text_qa(request, pk,
         'notesform': notesform,
         'ext_form': ext_form,
         'referer': referer
-        }
+    }
 
     if request.method == 'POST' and 'save' in request.POST:
-        #print(request.__dict__)
-        
-        ParentForm, ChildForm = create_detail_formset(doc, EXTRA)
+
+        ParentForm, ChildForm = create_detail_formset(
+            doc, EXTRA, can_delete=True, exclude=['weight_fraction_type'])
         # extext = extext.pull_out_cp()
         ext_form = ParentForm(request.POST, instance=extext)
         detail_formset = ChildForm(request.POST, instance=extext)
@@ -167,7 +169,7 @@ def extracted_text_qa(request, pk,
                 extext.qa_edited = True
                 extext.save()
                 # rebuild the formset after saving it
-                detail_formset = ChildForm( instance=extext)
+                detail_formset = ChildForm(instance=extext)
             else:
                 print(detail_formset.errors)
                 # TODO: iterate through this dict of errors and map each error to
@@ -175,23 +177,24 @@ def extracted_text_qa(request, pk,
 
             context['detail_formset'] = detail_formset
             context['ext_form'] = ext_form
-            context.update({'notesform' : notesform}) # calls the clean method? y?
+            # calls the clean method? y?
+            context.update({'notesform': notesform})
 
         # Add CSS selector classes to each form
         for form in detail_formset:
             for field in form.fields:
                 form.fields[field].widget.attrs.update(
                     {'class': f'detail-control form-control %s' % doc.data_group.type}
-                    )
+                )
 
-    elif request.method == 'POST' and 'approve' in request.POST: # APPROVAL
-        notesform =  QANotesForm(request.POST, instance=note)
+    elif request.method == 'POST' and 'approve' in request.POST:  # APPROVAL
+        notesform = QANotesForm(request.POST, instance=note)
         context['notesform'] = notesform
         nextpk = extext.next_extracted_text_in_qa_group()
         if notesform.is_valid():
             extext.qa_approved_date = timezone.now()
-            extext.qa_approved_by =  request.user
-            extext.qa_checked =  True
+            extext.qa_approved_by = request.user
+            extext.qa_checked = True
             extext.save()
             notesform.save()
             if referer == 'data_document':
@@ -199,8 +202,8 @@ def extracted_text_qa(request, pk,
                     reverse(referer, kwargs={'pk': pk}))
             elif not nextpk == 0:
                 return HttpResponseRedirect(
-                            reverse('extracted_text_qa', args=[(nextpk)]))
+                    reverse('extracted_text_qa', args=[(nextpk)]))
             elif nextpk == 0:
                 return HttpResponseRedirect(
-                            reverse('qa'))
+                    reverse('qa'))
     return render(request, template_name, context)


### PR DESCRIPTION
I solved this by adding a new `exclude` parameter to the `create_detail_formset()`method. Now when you call that method from a view, you can specify certain fields to be excluded from the rendered form.