### PR TITLE
#765 HOTFIX change stub upc generation

### DIFF
--- a/dashboard/tests/functional/test_datagroup_detail.py
+++ b/dashboard/tests/functional/test_datagroup_detail.py
@@ -9,6 +9,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth.models import User
 from django.test import Client
 from importlib import import_module
+from django.db.models import Max
 
 from dashboard.forms import *
 
@@ -117,6 +118,7 @@ class DataGroupDetailTest(TestCase):
         response = self.client.get(f'/datagroup/{self.objects.dg.pk}/')
         self.assertEqual(response.context['bulk'], 1,
                 'Not all DataDocuments linked to Product, bulk_create needed')
+        new_stub_id = Product.objects.all().aggregate(Max('id'))["id__max"] + 1
         response = self.client.post(f'/datagroup/{self.objects.dg.pk}/',
                                                                 {'bulk':1})
         self.assertEqual(response.context['bulk'], 0,
@@ -124,7 +126,8 @@ class DataGroupDetailTest(TestCase):
         product = ProductDocument.objects.get(document=doc).product
         self.assertEqual(product.title, 'unknown',
                                         'Title should be unknown in bulk_create')
-        self.assertEqual(product.upc, 'stub_2',
+        
+        self.assertEqual(product.upc, f'stub_%s' % new_stub_id,
                                     'UPC should be created for second Product')
 
     def test_upload_note(self):

--- a/dashboard/views/data_group.py
+++ b/dashboard/views/data_group.py
@@ -25,6 +25,7 @@ from dashboard.forms import (DataGroupForm,
                              include_extract_form,
                              include_clean_comp_data_form)
 from dashboard.utils import get_extracted_models, clean_dict, update_fields
+from django.db.models import Max
 
 
 @login_required()
@@ -152,7 +153,7 @@ def data_group_detail(request, pk,
         b = set(prod_link.values_list('document_id',flat=True))
         # DataDocs to make products for...
         docs_needing_products = DataDocument.objects.filter(pk__in=list(a-b))
-        stub = Product.objects.all().count() + 1
+        stub = Product.objects.all().aggregate(Max('id'))["id__max"] + 1
         for doc in docs_needing_products:
             # Try to name the new product from the ExtractedText record's prod_name
             try:

--- a/dashboard/views/product_curation.py
+++ b/dashboard/views/product_curation.py
@@ -15,6 +15,7 @@ from dashboard.forms import (ProductPUCForm, ProductLinkForm,
 from taggit.forms import TagField
 from taggit_labels.widgets import LabelWidget
 from django.core.paginator import Paginator
+from django.db.models import Max
 
 class FilteredLabelWidget(LabelWidget):
     # overriding django-taggit-label function to display subset of tags
@@ -86,7 +87,7 @@ def link_product_form(request, pk, template_name=('product_curation/'
                                                     'link_product_form.html')):
     doc = DataDocument.objects.get(pk=pk)
     ds_id = doc.data_group.data_source_id
-    initial = {   'upc': ('stub_' + str(Product.objects.all().count() + 1)),
+    initial = {   'upc': ('stub_' + str(Product.objects.all().aggregate(Max('id'))["id__max"] + 1)),
         'document_type': doc.document_type,
            'return_url': request.META.get('HTTP_REFERER')}
     form = ProductLinkForm(initial=initial)
@@ -118,6 +119,8 @@ def link_product_form(request, pk, template_name=('product_curation/'
                 return redirect('data_document', pk=doc.pk)
             else:
                 return redirect('link_product_list', pk=doc.data_group.pk)
+        else:
+            pass #form is invalid
     return render(request, template_name,{'document': doc, 'form': form})
 
 @login_required()


### PR DESCRIPTION
The numeric UPC index was previously generated by counting Product records and incrementing the count by one. This caused errors when a Product had been deleted, since the new index number matched a previously created one.