### PR TITLE
#988 change icon

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Django>=2.2,<2.3
 django-autocomplete-light==3.3.2
 django-bootstrap-datepicker-plus==3.0.5
 django-debug-toolbar==1.11
+django-extensions>=2.1.6
 django-haystack>=2.7.0
 django-haystack-elasticsearch>=0.1.0
 django-model-utils>=3.1
@@ -16,6 +17,7 @@ elasticsearch>=2.0.0,<3.0.0
 elasticsearch6>=6.0.0,<7.0.0
 fuzzywuzzy>=0.17.0
 gitpython>=2.1.11
+ipython>=7.5.0
 lxml>=4.2.2
 mysqlclient==1.4.2.post1
 pyflakes==2.1.1
@@ -25,6 +27,5 @@ requests==2.20.0
 urllib3==1.24.2
 selenium>=3.14.0
 wincertstore==0.2
-django-extensions>=2.1.6
 
 -e git+https://github.com/bennylope/django-taggit-labels.git@7afef34125653e958dc5dba0280904a0714aa808#egg=django_taggit_labels

--- a/templates/data_document/data_document_detail.html
+++ b/templates/data_document/data_document_detail.html
@@ -73,11 +73,11 @@
                 title="Download Script">
                 {{ doc.data_group.download_script }}
             </h5>
-            <a class="btn btn-info btn-sm float-right"
+            <a class="btn btn-secondary btn-sm float-right"
                 role="button"
                 title="Download Script"
                 href={{ doc.data_group.download_script.url }}>
-                <i class="fas fa-scroll"></i>
+                <i class="fab fa-github"></i>
             </a>
         {% endif %}
         <div class="pt-2"><!-- doc.note -->


### PR DESCRIPTION
I added `ipython` to the requirements here so I don't have to install it separately like I have been. I find it hard to believe that anyone is using the `manage.py shell` w/o it, but that may be the case.