### PR TITLE
1649: Remove Empty Data Groups from CP QA

### DIFF
--- a/dashboard/tests/functional/test_qa_seed_data.py
+++ b/dashboard/tests/functional/test_qa_seed_data.py
@@ -326,3 +326,13 @@ class TestQaPage(TestCase):
                 pass
 
             self.assertEqual(response.status_code, 200)
+
+    def test_cp_qa_no_extractedtext(self):
+        # before remove all extractedtext of group 49
+        response = self.client.get(f"/qa/chemicalpresence/")
+        self.assertIn(f"/qa/chemicalpresencegroup/49/".encode(), response.content)
+        # remove extractedtext of group 49
+        ExtractedText.objects.filter(data_document__data_group__id=49).delete()
+        # now this group should not show on page
+        response = self.client.get(f"/qa/chemicalpresence/")
+        self.assertNotIn(f"/qa/chemicalpresencegroup/49/".encode(), response.content)

--- a/dashboard/tests/functional/test_qa_summary.py
+++ b/dashboard/tests/functional/test_qa_summary.py
@@ -72,7 +72,9 @@ class TestQASummary(TestCase):
             response_html.xpath('//*[@id="qa_complete_extractedtext_count"]')[0].text,
         )
         self.assertIn(
-            str(QANotes.objects.filter(extracted_text__in=self.extracted_texts).count()),
+            str(
+                QANotes.objects.filter(extracted_text__in=self.extracted_texts).count()
+            ),
             response_html.xpath('//*[@id="qa_notes"]')[0].text,
         )
         self.assertIn(

--- a/dashboard/views/qa.py
+++ b/dashboard/views/qa.py
@@ -61,6 +61,8 @@ def qa_chemicalpresence_index(request, template_name="qa/chemical_presence_index
                 filter=Q(datadocument__extractedtext__qa_checked=True),
             )
         )
+        .annotate(extracted_count=Count("datadocument__extractedtext"))
+        .filter(extracted_count__gt=0)
     )
 
     return render(request, template_name, {"datagroups": datagroups})


### PR DESCRIPTION
1. For CP QA page, filter out datagroup that has no extracted texts.