### PR TITLE
1626: delete task after done

### DIFF
--- a/static/js/dashboard/product_delete.js
+++ b/static/js/dashboard/product_delete.js
@@ -17,6 +17,17 @@ $(document).ready(function () {
             }
         }
 
+        async function deleteTask(task_id) {
+            if (task_id) {
+                await fetch(`/api/tasks/${task_id}/`, {
+                    method: "DELETE",
+                    headers: { "X-CSRFToken": Cookies.get("csrftoken") }
+                }).then(res => console.log(res.ok));
+            } else {
+                return null;
+            }
+        }
+
         function taskDone(task) {
             // task considered done when success or fail
             return ["SUCCESS", "FAILURE"].includes(
@@ -36,6 +47,8 @@ $(document).ready(function () {
                 if (taskDone(task)) {
                     // task done, clear the pull interval
                     clearInterval(taskSchedule);
+                    // delete this task
+                    await deleteTask(task_id);
                     // direct to the originated url
                     window.location.href = redict_to;
                 }

--- a/templates/data_group/product_delete_progress.html
+++ b/templates/data_group/product_delete_progress.html
@@ -13,5 +13,6 @@
 {% endblock %}
 
 {% block js %}
+    <script src="{% static 'js/js.cookie.min.js' %}"></script>
     <script src="{% static 'js/dashboard/product_delete.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
1. After delete products task done, delete it. Otherwise, data group detail page will keep polling tasks and cause UI error in console log.
2. To test, verify that after the task is done and re-direct to data group detail page, no browser console error occurs.