### PR TITLE
Correct QA Status Calculations

### DIFF
--- a/dashboard/models/script.py
+++ b/dashboard/models/script.py
@@ -39,7 +39,8 @@ class Script(CommonInfo, QASummaryNote):
 
     def get_qa_group_count(self):
         return DataDocument.objects.filter(
-            extractedtext__qa_group__isnull=False, extractedtext__extraction_script=self.pk
+            extractedtext__qa_group__isnull=False,
+            extractedtext__extraction_script=self.pk,
         ).count()
 
     def get_qa_complete_extractedtext_count(self):

--- a/dashboard/models/script.py
+++ b/dashboard/models/script.py
@@ -102,7 +102,7 @@ class Script(CommonInfo, QASummaryNote):
         if len(texts) >= 100:
             import math
 
-            # Otherwise sample 20% of them
+            # Otherwise sample X% of them
             random_sample = math.ceil(len(texts) * QA_COMPLETE_PERCENTAGE)
             pks = list(
                 texts.values_list("pk", flat=True).order_by("?")[:random_sample]

--- a/dashboard/views/qa.py
+++ b/dashboard/views/qa.py
@@ -46,6 +46,7 @@ def qa_extractionscript_index(request, template_name="qa/extraction_script_index
         Script.objects.filter(extractedtext__in=texts, script_type="EX")
         .exclude(title="Manual (dummy)")
         .annotate(extractedtext_count=extractedtext_count)
+        .annotate(extractedtext_qa=extractedtext_qa)
         .annotate(percent_complete=percent_complete)
     )
     return render(request, template_name, {"extraction_scripts": extraction_scripts})
@@ -99,7 +100,12 @@ def qa_chemicalpresence_summary(
                 filter=Q(datadocument__extractedtext__qa_checked=True),
             )
         )
-        .annotate(qa_note_count=Count("datadocument__extractedtext__qanotes__qa_notes"))
+        .annotate(
+            qa_note_count=Count(
+                "datadocument__extractedtext__qanotes__qa_notes",
+                filter=~Q(datadocument__extractedtext__qanotes__qa_notes=""),
+            )
+        )
     ).first()
     datagroup.qa_incomplete_count = (
         datagroup.document_count - datagroup.qa_complete_count

--- a/dashboard/views/qa.py
+++ b/dashboard/views/qa.py
@@ -46,7 +46,6 @@ def qa_extractionscript_index(request, template_name="qa/extraction_script_index
         Script.objects.filter(extractedtext__in=texts, script_type="EX")
         .exclude(title="Manual (dummy)")
         .annotate(extractedtext_count=extractedtext_count)
-        .annotate(extractedtext_qa=extractedtext_qa)
         .annotate(percent_complete=percent_complete)
     )
     return render(request, template_name, {"extraction_scripts": extraction_scripts})

--- a/templates/qa/extraction_script_index.html
+++ b/templates/qa/extraction_script_index.html
@@ -40,7 +40,7 @@ QA: Composition - Ext. Script</h1>
         </td>
         <td id="qa-{{extraction_script.id}}">
          {% if extraction_script.extractedtext_count > 0 %}
-            {% if not extraction_script.qa_button_text == "QA Complete" %}
+            {% if extraction_script.qa_button_text != "QA Complete" %}
               <a class="btn btn-primary btn-sm col-12" role="button"
                 title="{{ extraction_script.qa_button_text }} on {{ extraction_script.title }}"
            href='{% url "qa_extraction_script" extraction_script.id %}'> {{ extraction_script.qa_button_text }}


### PR DESCRIPTION
I corrected the calculations on script.py, however the calculations in that file are in my opinion not necessary. The percent of QA documents checked is already calculated in the view in order to display it in the "Percent QA Checked" column, the template already has an if/else conditional so we could simply use that conditional to choose what text is displayed as well along with the style of the button. Chose to correct the calculations in case that file serves another purpose or if was done that way to future proof something (couldn't find any other portion of the code using it though). I would also change the return from a string to something more useful.   