### PR TITLE
Remove unnecessary calculation from script.py

### DIFF
--- a/dashboard/views/qa.py
+++ b/dashboard/views/qa.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 from django.utils.http import is_safe_url
 from django.utils.timesince import timesince
 from django_datatables_view.base_datatable_view import BaseDatatableView
+from django_mysql.models import add_QuerySetMixin
 
 from celery_usertask.tasks import UserTask, usertask
 from dashboard.forms import create_detail_formset, QANotesForm, DocumentTypeForm
@@ -43,7 +44,8 @@ def qa_extractionscript_index(request, template_name="qa/extraction_script_index
         data_document__data_group__group_type__code="CP"
     )  # remove the scripts with CP texts that are associated
     extraction_scripts = (
-        Script.objects.filter(extractedtext__in=texts, script_type="EX")
+        add_QuerySetMixin(Script.objects.all())
+        .filter(extractedtext__in=texts, script_type="EX")
         .exclude(title="Manual (dummy)")
         .annotate(extractedtext_count=extractedtext_count)
         .annotate(percent_complete=percent_complete)

--- a/templates/qa/extraction_script_index.html
+++ b/templates/qa/extraction_script_index.html
@@ -46,15 +46,15 @@ QA: Composition - Ext. Script</h1>
               <a class="btn btn-light btn-sm col-12" disabled role="button"
                 title="QA Complete on {{ extraction_script.title }}"> QA Complete
                 </a>
-            {% elif extraction_script.percent_complete == 0 %}
-              <a class="btn btn-primary btn-sm col-12" role="button"
-                title="Begin QA on {{ extraction_script.title }}"
-           href='{% url "qa_extraction_script" extraction_script.id %}'> Begin QA
+            {% elif extraction_script.qa_begun %}
+                <a class="btn btn-primary btn-sm col-12" role="button"
+                   title="QA started on {{ extraction_script.title }}"
+                   href='{% url "qa_extraction_script" extraction_script.id %}'> Continue QA
                 </a>
             {% else %}
               <a class="btn btn-primary btn-sm col-12" role="button"
-                title="QA started on {{ extraction_script.title }}"
-           href='{% url "qa_extraction_script" extraction_script.id %}'> Continue QA
+                 title="Begin QA on {{ extraction_script.title }}"
+                 href='{% url "qa_extraction_script" extraction_script.id %}'> Begin QA
                 </a>
             {% endif %}
         {% endif %}

--- a/templates/qa/extraction_script_index.html
+++ b/templates/qa/extraction_script_index.html
@@ -41,17 +41,23 @@ QA: Composition - Ext. Script</h1>
             </a>
         </td>
         <td id="qa-{{extraction_script.id}}">
-         {% if extraction_script.extractedtext_count > 0 %}
-            {% if extraction_script.qa_button_text != "QA Complete" %}
+        {% if extraction_script.extractedtext_count > 0 %}
+            {% if extraction_script.percent_complete == 100 %}
+              <a class="btn btn-light btn-sm col-12" disabled role="button"
+                title="QA Complete on {{ extraction_script.title }}"> QA Complete
+                </a>
+            {% elif extraction_script.percent_complete == 0 %}
               <a class="btn btn-primary btn-sm col-12" role="button"
-                title="{{ extraction_script.qa_button_text }} on {{ extraction_script.title }}"
-           href='{% url "qa_extraction_script" extraction_script.id %}'> {{ extraction_script.qa_button_text }}
+                title="Begin QA on {{ extraction_script.title }}"
+           href='{% url "qa_extraction_script" extraction_script.id %}'> Begin QA
                 </a>
             {% else %}
-              <a class="btn btn-light btn-sm col-12" disabled role="button">
-                {{ extraction_script.qa_button_text }}</a>
+              <a class="btn btn-primary btn-sm col-12" role="button"
+                title="QA started on {{ extraction_script.title }}"
+           href='{% url "qa_extraction_script" extraction_script.id %}'> Continue QA
+                </a>
             {% endif %}
-         {% endif %}
+        {% endif %}
         </td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
As I mentioned in merge request:

https://github.com/HumanExposure/factotum/pull/1750

I believe the calculations in that file(script.py) are in my opinion not necessary. It took me a while to find, but that was the cause for the repeated 380+ queries, even though the info was already available in the qa.py view. I got rid of the reference to that file in the template and just used the info already available from qa.py. That part of the code in script.py is now not been used at all (or so I believe). Left it, in case I am wrong.