### PR TITLE
1777: functional use extraction script QA page

### DIFF
--- a/dashboard/tests/functional/test_datadocument_detail.py
+++ b/dashboard/tests/functional/test_datadocument_detail.py
@@ -264,7 +264,6 @@ class DataDocumentDetailTest(TransactionTestCase):
         hhe_no = response_html.xpath('//*[@id="id_hhe_report_number"]')[0].text
         self.assertIn("47", hhe_no)
 
-
     def test_delete(self):
         doc_pk = 354784
         doc = DataDocument.objects.get(pk=doc_pk)
@@ -619,29 +618,23 @@ class TestDynamicDetailFormsets(TestCase):
         # the new first card should match the second ID
         self.assertEqual(cards[0].get("id"), f"chem-{second_id}")
         self.client.post(
-                path=reverse("detected_flag_toggle_yes", kwargs={"doc_pk": 170415}),
-                data={
-                    'chems': ['93','557'],
-                },
+            path=reverse("detected_flag_toggle_yes", kwargs={"doc_pk": 170415}),
+            data={"chems": ["93", "557"]},
         )
-        self.assertEqual(exchems.get(id=93).chem_detected_flag,'1')
-        self.assertEqual(exchems.get(id=557).chem_detected_flag,'1')
+        self.assertEqual(exchems.get(id=93).chem_detected_flag, "1")
+        self.assertEqual(exchems.get(id=557).chem_detected_flag, "1")
         self.client.post(
-                path=reverse("detected_flag_toggle_no", kwargs={"doc_pk": 170415}),
-                data={
-                    'chems': ['93','557'],
-                },
+            path=reverse("detected_flag_toggle_no", kwargs={"doc_pk": 170415}),
+            data={"chems": ["93", "557"]},
         )
-        self.assertEqual(exchems.get(id=93).chem_detected_flag,'0')
-        self.assertEqual(exchems.get(id=557).chem_detected_flag,'0')
+        self.assertEqual(exchems.get(id=93).chem_detected_flag, "0")
+        self.assertEqual(exchems.get(id=557).chem_detected_flag, "0")
         self.client.post(
-                path=reverse("detected_flag_reset", kwargs={"doc_pk": 170415}),
-                data={
-                    'chems': ['93','557'],
-                },
+            path=reverse("detected_flag_reset", kwargs={"doc_pk": 170415}),
+            data={"chems": ["93", "557"]},
         )
-        self.assertEqual(exchems.get(id=93).chem_detected_flag,None)
-        self.assertEqual(exchems.get(id=557).chem_detected_flag,None)
+        self.assertEqual(exchems.get(id=93).chem_detected_flag, None)
+        self.assertEqual(exchems.get(id=557).chem_detected_flag, None)
 
     def test_functional_use_chemical_cards(self):
         data_document = DataDocument.objects.get(pk=5)
@@ -685,4 +678,3 @@ class TestDynamicDetailFormsets(TestCase):
             content_object__extracted_text__data_document_id=doc_id
         ).count()
         self.assertEqual(0, tags_count, "should removed all tags")
-

--- a/dashboard/tests/functional/test_qa_seed_data.py
+++ b/dashboard/tests/functional/test_qa_seed_data.py
@@ -36,13 +36,13 @@ class TestQaPage(TestCase):
         )
 
     def test_new_qa_group_urls(self):
-        # Begin from the QA index page
+        # Script 5 has ExtractedText object
+        pk = 5
         response = self.client.get(f"/qa/compextractionscript/")
+        self.assertIn("Composition - Ext. Script".encode(), response.content)
         self.assertIn(
-            f"/qa/compextractionscript/15/'> Begin QA".encode(), response.content
+            f"/qa/compextractionscript/{pk}/'> Begin QA".encode(), response.content
         )
-        # Script 15 has one ExtractedText object
-        pk = 15
         response = self.client.get(f"/qa/compextractionscript/{pk}/")
         et = ExtractedText.objects.filter(extraction_script=pk).first()
         self.assertIn(f"/qa/extractedtext/{et.pk}/".encode(), response.content)
@@ -51,7 +51,7 @@ class TestQaPage(TestCase):
         group_count = QAGroup.objects.filter(extraction_script_id=pk).count()
         self.assertTrue(group_count == 1)
         # The ExtractionScript's qa_begun property should be set to True
-        self.assertTrue(Script.objects.get(pk=15).qa_begun)
+        self.assertTrue(Script.objects.get(pk=pk).qa_begun)
         # The ExtractedText object should be assigned to the QA Group
         group_pk = QAGroup.objects.get(extraction_script_id=pk).pk
         et = ExtractedText.objects.filter(extraction_script=pk).first()
@@ -59,7 +59,7 @@ class TestQaPage(TestCase):
         # The link on the QA index page should now say "Continue QA"
         response = self.client.get(f"/qa/compextractionscript/")
         self.assertIn(
-            f"'/qa/compextractionscript/15/'> Continue QA".encode(), response.content
+            f"'/qa/compextractionscript/{pk}/'> Continue QA".encode(), response.content
         )
 
     def test_doc_fields(self):
@@ -69,11 +69,18 @@ class TestQaPage(TestCase):
         self.assertIn("A list of chemicals with a subtitle".encode(), response.content)
         self.assertIn("Total Chemical Records".encode(), response.content)
 
+    def test_qa_func_use_script(self):
+        response = self.client.get("/qa/compextractionscript/?group_type=FU")
+        self.assertIn(
+            "/qa/compextractionscript/15/'> Begin QA".encode(), response.content
+        )
+        self.assertIn("Functional use - Ext. Script".encode(), response.content)
+
     def test_qa_script_without_ext_text(self):
         # Begin from the QA index page
         response = self.client.get(f"/qa/compextractionscript/")
         self.assertIn(
-            f"/qa/compextractionscript/15/'> Begin QA".encode(), response.content
+            f"/qa/compextractionscript/5/'> Begin QA".encode(), response.content
         )
         # Script 9 has no ExtractedText objects
         pk = 9

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
         "datadocument/detected/<int:doc_pk>/",
         views.detected_flag,
         name="detected_flag_toggle_yes",
-    ),    
+    ),
     path(
         "datadocument/non_detected/<int:doc_pk>/",
         views.detected_flag,

--- a/dashboard/views/data_document.py
+++ b/dashboard/views/data_document.py
@@ -450,26 +450,26 @@ def list_presence_tag_delete(request, doc_pk, chem_pk, tag_pk):
     return redirect(url)
 
 
-
 @login_required
 def detected_flag(request, doc_pk):
     chems = request.POST.getlist("chems")
     flag_set = int
-    if 'non_detected' in request.get_full_path():
+    if "non_detected" in request.get_full_path():
         flag_set = 0
-    elif 'detected' in request.get_full_path():
+    elif "detected" in request.get_full_path():
         flag_set = 1
-    elif 'clear_flag' in request.get_full_path():
+    elif "clear_flag" in request.get_full_path():
         flag_set = None
     else:
         pass
 
-    for chem in chems: 
+    for chem in chems:
         elp = RawChem.objects.get(pk=chem)
-        elp.chem_detected_flag=flag_set
+        elp.chem_detected_flag = flag_set
         elp.save()
     url = reverse("data_document", args=[doc_pk])
     return redirect(url)
+
 
 @login_required
 def habits_and_practices_tag_delete(request, doc_pk, chem_pk, tag_pk):

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -182,6 +182,10 @@
                             Composition - Ext. Script
                         </a>
                         <a class="dropdown-item"
+                           href="{% url 'qa_extractionscript_index' %}?group_type=FU">
+                            Functional Use - Ext. Script
+                        </a>
+                        <a class="dropdown-item"
                            href="{% url 'qa_chemicalpresence_index' %}">
                             Chemical Presence
                         </a>

--- a/templates/qa/extraction_script_index.html
+++ b/templates/qa/extraction_script_index.html
@@ -1,10 +1,11 @@
 {% extends 'core/base.html' %}
 {% load staticfiles %}
 {% load humanize %}
+{% block title %}QA Extraction Script{% endblock %}
 
 {% block content %}
 <h1 class="col-sm-12"><span class="fa fa-check-square" title="factotum"></span>
-QA: Composition - Ext. Script</h1>
+QA: {{ group_type.title }} - Ext. Script</h1>
 <br>
 
     <table class="table table-striped table-bordered dataTable no-footer" id='extraction_script_table'>


### PR DESCRIPTION
1. Modified current /compextractionscript endpoint to accept group_type parameter, so we can re-use the views/templates. For Functional use page, use ?group_type=FU.
2. For existing Composition Ext. Script page, Sakshi agreed to show CO type only
To test:
Go to QA -> Functional Use - Ext. Script page.