### PR TITLE
1811: search data group tracking table by column value

### DIFF
--- a/dashboard/tests/integration/test_browser_edits.py
+++ b/dashboard/tests/integration/test_browser_edits.py
@@ -529,6 +529,12 @@ class TestEditsWithSeedData(StaticLiveServerTestCase):
                 f"//*[@id='datagroups']/thead/tr/th[{col_index}]"
             )
             self.assertEqual(step.name, step_header.text)
+            search_header = self.browser.find_element_by_xpath(
+                f"//*[@id='datagroups']/thead/tr[2]/th[{col_index}]"
+            )
+            self.assertIn("Incomplete", search_header.text)
+            self.assertIn("Complete", search_header.text)
+            self.assertIn("N/A", search_header.text)
             step_cell = self.browser.find_element_by_xpath(
                 f"//*[@id='datagroups']/tbody/tr[1]/td[{col_index}]"
             )
@@ -569,3 +575,33 @@ class TestEditsWithSeedData(StaticLiveServerTestCase):
             self.assertEqual("N/A", step_field.first_selected_option.text)
         workflow_field = self.browser.find_element_by_id("id_workflow_complete")
         self.assertTrue(workflow_field.get_attribute("checked"))
+
+        # test search by column
+        self.browser.get(url)
+        time.sleep(1)
+        search_ds = self.browser.find_element_by_xpath(
+            "//*[@id='datagroups']/thead/tr[2]/th[1]/input"
+        )
+        search_ds.send_keys("airgas")
+        self.assertInHTML(
+            "Showing 1 to 4 of 4 entries (filtered from 24 total entries)",
+            self.browser.find_element_by_xpath("//*[@id='datagroups_info']").text,
+        )
+        search_ds.send_keys("")
+        status_options = self.browser.find_element_by_xpath(
+            "//*[@id='datagroups']/thead/tr[2]/th[6]/select"
+        )
+        Select(status_options).select_by_visible_text("Complete")
+        self.assertInHTML(
+            "Showing 0 to 0 of 0 entries (filtered from 24 total entries)",
+            self.browser.find_element_by_xpath("//*[@id='datagroups_info']").text,
+        )
+        Select(status_options).select_by_index(0)
+        complete_options = self.browser.find_element_by_xpath(
+            "//*[@id='datagroups']/thead/tr[2]/th[13]/select"
+        )
+        Select(complete_options).select_by_visible_text("Yes")
+        self.assertInHTML(
+            "Showing 1 to 1 of 1 entries (filtered from 24 total entries)",
+            self.browser.find_element_by_xpath("//*[@id='datagroups_info']").text,
+        )

--- a/dashboard/tests/integration/test_data_document_detail.py
+++ b/dashboard/tests/integration/test_data_document_detail.py
@@ -405,9 +405,11 @@ class TestEditsWithSeedData(StaticLiveServerTestCase):
         with self.assertRaises(NoSuchElementException):
             self.browser.find_element_by_id("id_pmid")
 
-        self.browser.find_element_by_xpath(
+        edit_btn = self.browser.find_element_by_xpath(
             '//*[@id="btn-add-or-edit-extracted-text"]'
-        ).click()
+        )
+        self.browser.execute_script("arguments[0].click();", edit_btn)
+
         save_button = wait.until(
             ec.element_to_be_clickable(
                 (By.XPATH, "//*[@id='extracted-text-modal-save']")
@@ -415,15 +417,11 @@ class TestEditsWithSeedData(StaticLiveServerTestCase):
         )
         # problem: the form on the data document detail page and on the modal
         # editor have the same id, so the full ugly xpath is needed
-        study_type_menu = self.browser.find_element_by_xpath(
-            "/html/body/div[1]/div[2]/div[1]/div[5]/div[3]/div/div/form/div[1]/div/div[2]/select"
-        )
+        study_type_menu = self.browser.find_element_by_name("study_type")
         Select(study_type_menu).select_by_visible_text(
             "Non-Targeted or Suspect Screening"
         )
-        media_input = self.browser.find_element_by_xpath(
-            "/html/body/div[1]/div[2]/div[1]/div[5]/div[3]/div/div/form/div[1]/div/div[3]/textarea"
-        )
+        media_input = self.browser.find_element_by_name("media")
         media_input.send_keys("Lorem ipso fido leash")
         save_button.click()
 

--- a/static/js/dashboard/data_group_tracking.js
+++ b/static/js/dashboard/data_group_tracking.js
@@ -1,6 +1,32 @@
-$(document).ready(function () {
+$(document).ready(function() {
+    // Setup - add a text input to each header cell
+    // $('#datagroups thead tr').clone(true).appendTo('#datagroups thead');
+    $('#datagroups thead tr:eq(1) th').each(function(i) {
+        var isStep = $(this).hasClass("search-curation-step");
+        if (isStep) {
+            $("select", this).change(function() {
+                // search by whole word
+                var searchTerm = $(this).children("option:selected").val();
+                var regex = '\\b' + searchTerm + '\\b';
+                if (table.column(i).search() !== this.searchTerm) {
+                    table.column(i).search(regex, true, false).draw();
+                }
+            });
+        } else {
+            $('input', this).on('keyup change', function() {
+                if (table.column(i).search() !== this.value) {
+                    table.column(i).search(this.value).draw();
+                }
+            });
+        }
+    });
+
     var table = $('#datagroups').DataTable({
         "lengthMenu": [25, 50, 75, 100], // change number of records shown
         "order": [],
+        orderCellsTop: true,
+        "columnDefs": [
+            {"orderable": false, "targets": [-1]}
+        ]
     });
 });

--- a/templates/data_group/data_group_tracking.html
+++ b/templates/data_group/data_group_tracking.html
@@ -10,16 +10,42 @@
     <p class="alert-success" id="result-message"></p>
 
     <table class="table table-striped table-bordered dataTable no-footer table-sm" id="datagroups">
-        <thead class="table-primary">
-        <th>Data Source</th>
-        <th>Data Group</th>
-        <th>Group Type</th>
-        <th>Date Updated</th>
-        {% for step in curationsteps %}
-            <th>{{ step.name }}</th>
-        {% endfor %}
-        <th>Workflow Complete</th>
-        <th></th>
+        <thead>
+        <tr class="table-primary">
+            <th>Data Source</th>
+            <th>Data Group</th>
+            <th>Group Type</th>
+            <th>Date Updated</th>
+            {% for step in curationsteps %}
+                <th>{{ step.name }}</th>
+            {% endfor %}
+            <th>Workflow Complete</th>
+            <th></th>
+        </tr>
+        <tr>
+            <th><input type="text" aria-label="search data source" placeholder="Search Date Source"></th>
+            <th><input type="text" aria-label="search data group" placeholder="Search Date Group"></th>
+            <th><input type="text" aria-label="search group type" placeholder="Search Group Type"></th>
+            <th><input type="text" aria-label="search data updated" placeholder="Search Date Updated"></th>
+            {% for step in curationsteps %}
+                <th class="search-curation-step">
+                    <select name="step-status" aria-label="search {{ step.name }}">
+                        <option value="" selected>Search Status</option>
+                        <option value="incomplete">Incomplete</option>
+                        <option value="complete">Complete</option>
+                        <option value="n/a">N/A</option>
+                    </select>
+                </th>
+            {% endfor %}
+            <th class="search-curation-step">
+                <select name="step-status" aria-label="search workflow complete">
+                    <option value="" selected>Search Status</option>
+                    <option value="yes">Yes</option>
+                    <option value="no">No</option>
+                </select>
+            </th>
+            <th></th>
+        </tr>
         </thead>
         <tbody>
         {% for datagroup in datagroups %}


### PR DESCRIPTION
Added search per column in data group tracking table.
To test, go to Data Curation -> Data Group Tracking page, use can filter by curation step status. The search is cumulative.