### PR TITLE
1826 puc table link

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -161,7 +161,7 @@ class DocumentTypeAdmin(admin.ModelAdmin):
 
 
 class FunctionalUseAdmin(admin.ModelAdmin):
-    list_display = ("chem","report_funcuse","category")
+    list_display = ("chem", "report_funcuse", "category")
     list_filter = ("report_funcuse",)
 
 

--- a/dashboard/tests/integration/test_puc_detail.py
+++ b/dashboard/tests/integration/test_puc_detail.py
@@ -1,3 +1,5 @@
+from selenium.webdriver import ActionChains
+
 from dashboard.tests.loader import fixtures_standard, load_browser
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from dashboard.models import PUC
@@ -73,5 +75,47 @@ class TestPUCProductAndDocumentTables(StaticLiveServerTestCase):
         wait.until(
             ec.text_to_be_present_in_element(
                 (By.XPATH, "//*[@id='chemicals']/tbody/tr/td[1]/a"), "DTXSID9022528"
+            )
+        )
+
+    def test_additional_statistics_links_open_appropriate_table(self):
+        puc = PUC.objects.get(pk=185)
+        wait = WebDriverWait(self.browser, 10)
+        actions = ActionChains(self.browser)
+
+        self.browser.get(self.live_server_url + puc.get_absolute_url())
+
+        # Data Documents
+        doc_btn = self.browser.find_element_by_xpath(
+            "//div[@id='puc_stats']//a[@onclick=\"activateTable('#document-tab-header')\"]"
+        )
+        actions.move_to_element(doc_btn).click().perform()
+        wait.until(
+            ec.text_to_be_present_in_element(
+                (By.XPATH, "//*[@id='documents']/tbody/tr[1]/td[1]/a"),
+                "body butter (PLP) Recertification",
+            )
+        )
+
+        # Chemicals
+        chem_btn = self.browser.find_element_by_xpath(
+            "//div[@id='puc_stats']//a[@onclick=\"activateTable('#chemical-tab-header')\"]"
+        )
+        actions.move_to_element(chem_btn).click().perform()
+        wait.until(
+            ec.text_to_be_present_in_element(
+                (By.XPATH, "//*[@id='chemicals']/tbody/tr/td[1]/a"), "DTXSID9022528"
+            )
+        )
+
+        # Products
+        prod_btn = self.browser.find_element_by_xpath(
+            "//div[@id='puc_stats']//a[@onclick=\"activateTable('#product-tab-header')\"]"
+        )
+        actions.move_to_element(prod_btn).click().perform()
+        wait.until(
+            ec.text_to_be_present_in_element(
+                (By.XPATH, "//*[@id='products']/tbody/tr[3]/td[1]/a"),
+                "Rose Whipped Body Lotion",
             )
         )

--- a/static/js/dashboard/puc_detail.js
+++ b/static/js/dashboard/puc_detail.js
@@ -90,3 +90,7 @@ $(document).ready(function () {
     });
     $("#product-tab-header").click()
 });
+
+function activateTable(tableID) {
+    $(tableID).click()
+}

--- a/templates/puc/puc_detail.html
+++ b/templates/puc/puc_detail.html
@@ -67,13 +67,13 @@
             <h4>Additional Statistics</h4>
             <dl class="row">
                 <dt class="col-6">Products</dt>
-                <dd class="col-6"><a href="#tables">{{ puc.product_count }}</a></dd>
+                <dd class="col-6"><a href="#tables" onclick="activateTable('#product-tab-header')">{{ puc.product_count }}</a></dd>
                 <dt class="col-6">Cumulative Products</dt>
                 <dd class="col-6">{{ puc.cumulative_product_count }}</dd>
-                <dt class="col-6">Curated Chemicals</dt>
-                <dd class="col-6"><a href="#tables">{{ puc.curated_chemical_count }}</a></dd>
                 <dt class="col-6">Documents</dt>
-                <dd class="col-6"><a href="#tables">{{ puc.document_count }}</a> </dd>
+                <dd class="col-6"><a href="#tables" onclick="activateTable('#document-tab-header')">{{ puc.document_count }}</a> </dd>
+                <dt class="col-6">Curated Chemicals</dt>
+                <dd class="col-6"><a href="#tables" onclick="activateTable('#chemical-tab-header')">{{ puc.curated_chemical_count }}</a></dd>
             </dl>
         </div>
         <div class="col-6" id="taxonomies">


### PR DESCRIPTION
closes #1826 

Fires a click event on each panel when the associated anchor is clicked.

This is somewhat unnecessary, but the table only loads on each click in an attempt to lighten the page's load.  Rather than abstract logic out to separate the "click" and "load" functionality, it's much easier just to fire a click event.