### PR TITLE
1785 Add test for PUC filtering on chemical detail page

### DIFF
--- a/dashboard/fixtures/12_product_to_puc.yaml
+++ b/dashboard/fixtures/12_product_to_puc.yaml
@@ -158,17 +158,6 @@
     classification_method_id: MA
     classification_confidence: '1.000'
 - model: dashboard.producttopuc
-  pk: 20
-  fields:
-    created_at: 2019-05-10 14:45:56.307215
-    updated_at: 2019-05-10 14:45:56.307244
-    product: 878
-    puc: 137
-    puc_assigned_usr: 1
-    puc_assigned_script: null
-    classification_method_id: AU
-    classification_confidence: '1.000'
-- model: dashboard.producttopuc
   pk: 16
   fields:
     created_at: 2019-11-06 12:12:39.603403

--- a/dashboard/fixtures/12_product_to_puc.yaml
+++ b/dashboard/fixtures/12_product_to_puc.yaml
@@ -158,6 +158,17 @@
     classification_method_id: MA
     classification_confidence: '1.000'
 - model: dashboard.producttopuc
+  pk: 20
+  fields:
+    created_at: 2019-05-10 14:45:56.307215
+    updated_at: 2019-05-10 14:45:56.307244
+    product: 878
+    puc: 137
+    puc_assigned_usr: 1
+    puc_assigned_script: null
+    classification_method_id: AU
+    classification_confidence: '1.000'
+- model: dashboard.producttopuc
   pk: 16
   fields:
     created_at: 2019-11-06 12:12:39.603403

--- a/dashboard/tests/integration/test_chemical_detail.py
+++ b/dashboard/tests/integration/test_chemical_detail.py
@@ -8,6 +8,7 @@ from dashboard.models import (
     PUCKind,
     DataDocument,
     ExtractedComposition,
+    ProductToPUC,
 )
 
 from selenium.webdriver.common.by import By
@@ -320,7 +321,11 @@ class TestChemicalDetail(StaticLiveServerTestCase):
             "Showing 1 to 1 of 1 entries related to PUC Personal care (filtered from 6 total products)",
             self.browser.find_element_by_xpath("//*[@id='products_info']").text,
         )
-        # PUC 137 is assigned with the AU method to product 878, make sure it does
+
+        ProductToPUC.objects.create(
+            product_id=878, classification_method_id="BA", puc_id=137
+        )
+        # Now PUC 137 is assigned with the AU method to product 878, make sure it does
         # not appear in the filtered product table
         with self.assertRaises(AssertionError):
             self.assertInHTML(

--- a/dashboard/tests/integration/test_chemical_detail.py
+++ b/dashboard/tests/integration/test_chemical_detail.py
@@ -304,7 +304,8 @@ class TestChemicalDetail(StaticLiveServerTestCase):
                 (By.XPATH, "//*[@id='products_info']"), "Showing 1 to 6 of 6 entries"
             )
         )
-        # filter by puc
+        # filter by PUC
+
         puc_filter = self.browser.find_element_by_id("filter-137")
         puc_filter.click()
         time.sleep(1)
@@ -314,17 +315,30 @@ class TestChemicalDetail(StaticLiveServerTestCase):
         )
         puc_filter_icon = puc_filter.find_element_by_class_name("icon-primary")
         self.assertIsNotNone(puc_filter_icon)
+        # Products table
+        self.assertInHTML(
+            "Showing 1 to 1 of 1 entries related to PUC Personal care (filtered from 6 total products)",
+            self.browser.find_element_by_xpath("//*[@id='products_info']").text,
+        )
+        # PUC 137 is assigned with the AU method to product 878, make sure it does
+        # not appear in the filtered product table
+        with self.assertRaises(AssertionError):
+            self.assertInHTML(
+                "Radio Control Vehicle",
+                self.browser.find_element_by_xpath("//*[@id='products']").text,
+            )
 
         # Documents table
         self.assertInHTML(
             "Showing 1 to 1 of 1 entries related to PUC Personal care (filtered from 19 total documents)",
             self.browser.find_element_by_xpath("//*[@id='documents_info']").text,
         )
-        # Products table
-        self.assertInHTML(
-            "Showing 1 to 1 of 1 entries related to PUC Personal care (filtered from 6 total products)",
-            self.browser.find_element_by_xpath("//*[@id='products_info']").text,
-        )
+        # Make sure the document is also being excluded
+        with self.assertRaises(AssertionError):
+            self.assertInHTML(
+                "Radio Control Vehicle",
+                self.browser.find_element_by_xpath("//*[@id='documents']").text,
+            )
 
         # Clear filter by puc
         puc_filter.click()

--- a/dashboard/views/ajax.py
+++ b/dashboard/views/ajax.py
@@ -60,7 +60,7 @@ class DocumentListJson(FilterDatatableView):
         puc = self.request.GET.get("puc")
         sid = self.request.GET.get("sid")
         if puc:
-            return qs.filter(Q(products__puc=puc)).distinct()
+            return qs.filter(Q(products__product_uber_puc__puc=puc)).distinct()
         if sid:
             return qs.filter(Q(extractedtext__rawchem__dsstox__sid=sid)).distinct()
         return qs
@@ -84,7 +84,7 @@ class DocumentListJson(FilterDatatableView):
         pid = self.request.GET.get("pid")
         group_type = self.request.GET.get("group_type")
         if puc:
-            qs = qs.filter(Q(products__puc=puc))
+            qs = qs.filter(Q(products__product_uber_puc__puc=puc))
         if group_type:
             if group_type != "-1":
                 qs = qs.filter(data_group__group_type__id=group_type)


### PR DESCRIPTION
Closes: #1785 

This adds a test to confirm that the changes in #1282 corrected the Products shown when the user filters the chemical detail page on a PUC. It also includes a fix to the documents table on that page. 

The tables previously failed to respect the uberpuc assignments - when the AJAX query returned a set of products filtered by a PUC, the PUC was arbitrarily chosen from among all the PUCs assigned to the product. Now it uses the uberpuc selection logic. 

To reproduce the now-fixed error on the Documents table:

*On a branch other than this one,* and with the production data loaded, open the chemical detail page for Formaldehyde: `http://127.0.0.1:8000/chemical/DTXSID7020637/`

Click the filter button next to "Personal Care" to filter by that PUC. The number of Documents and Products will differ because some of the Documents are related to Products assigned to the Personal Care PUC where Personal Care is not the uberpuc.

Switch to this branch, reload the page, and the Documents that match those Products should disappear. 