### PR TITLE
Add table divider and functional uses table in chemical detail page

### DIFF
--- a/dashboard/fixtures/18_functional_use.yaml
+++ b/dashboard/fixtures/18_functional_use.yaml
@@ -83,13 +83,6 @@
     chem: 757
     report_funcuse: fragrance
 - model: dashboard.functionaluse
-  pk: 16
-  fields:
-    created_at: 2020-01-30 02:45:44.191430
-    updated_at: 2020-01-30 02:45:44.191449
-    chem: 758
-    report_funcuse: propellant
-- model: dashboard.functionaluse
   pk: 9
   fields:
     created_at: 2020-01-30 02:45:44.192008
@@ -138,3 +131,18 @@
     updated_at: 2020-01-30 02:45:44.193532
     chem: 389
     report_funcuse: fresh scent
+- model: dashboard.functionaluse
+  pk: 16
+  fields:
+    created_at: 2020-01-30 02:45:44.191430
+    updated_at: 2020-01-30 02:45:44.191449
+    chem: 758
+    report_funcuse: propellant
+- model: dashboard.functionaluse
+  pk: 17
+  fields:
+    created_at: 2020-01-30 02:45:44.193517
+    updated_at: 2020-01-30 02:45:44.193532
+    chem: 92
+    report_funcuse: solvent
+    category: 3

--- a/dashboard/tests/functional/test_chemical_detail.py
+++ b/dashboard/tests/functional/test_chemical_detail.py
@@ -157,3 +157,17 @@ class ChemicalDetail(TestCase):
         self.assertEqual(response.status_code, 200)
         content = response.get("Content-Disposition")
         self.assertTrue(content.startswith("attachment; filename=dtxsid6026296"))
+
+    def test_chemical_functional_uses(self):
+        sid = "DTXSID9022528"
+        response = self.client.get(f"/chemical_functional_use_json/?sid={sid}")
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEqual(data["recordsTotal"], 2)
+        self.assertEqual(data["recordsFiltered"], 2)
+
+        response = self.client.get(f"/chemical_functional_use_json/?sid={sid}&puc=137")
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEqual(data["recordsTotal"], 2)
+        self.assertEqual(data["recordsFiltered"], 0)

--- a/dashboard/tests/functional/test_functional_use_curation.py
+++ b/dashboard/tests/functional/test_functional_use_curation.py
@@ -17,7 +17,7 @@ class TestFunctionalUseCuration(TestCase):
     def test_functional_use_list(self):
         response = self.client.get(reverse("functional_use_curation"))
         combinations = response.context["combinations"]
-        self.assertEqual(len(combinations), 15, "THere should be 15 combinations")
+        self.assertEqual(len(combinations), 16, "THere should be 16 combinations")
 
         surfactants = FunctionalUse.objects.filter(report_funcuse="surfactant")
 
@@ -51,5 +51,5 @@ class TestFunctionalUseCuration(TestCase):
         response = self.client.get(reverse("functional_use_curation"))
         combinations = response.context["combinations"]
         self.assertEqual(
-            len(combinations), 14, "There should be 14 combinations after the edit"
+            len(combinations), 15, "There should be 15 combinations after the edit"
         )

--- a/dashboard/tests/integration/test_chemical_detail.py
+++ b/dashboard/tests/integration/test_chemical_detail.py
@@ -46,15 +46,10 @@ class TestChemicalDetail(StaticLiveServerTestCase):
         should be returned via ajax calls and included in the tables
         """
         chemical = DSSToxLookup.objects.get(sid="DTXSID9022528")
-        puc = PUC.objects.get(pk=185)
         wait = WebDriverWait(self.browser, 10)
         self.browser.get(self.live_server_url + chemical.get_absolute_url())
 
-        wait.until(
-            ec.text_to_be_present_in_element(
-                (By.XPATH, "//*[@id='products_info']"), "Showing 1 to 4 of 4 entries"
-            )
-        )
+        wait.until(ec.visibility_of_element_located((By.ID, "products_info")))
         self.assertInHTML(
             "Showing 1 to 4 of 4 entries",
             self.browser.find_element_by_xpath("//*[@id='products_info']").text,
@@ -77,14 +72,18 @@ class TestChemicalDetail(StaticLiveServerTestCase):
 
         # Data Documents
         self.browser.find_element_by_id("document-tab-header").send_keys("\n")
-        wait.until(
-            ec.text_to_be_present_in_element(
-                (By.XPATH, "//*[@id='documents_info']"), "Showing 1 to 2 of 2 entries"
-            )
-        )
+        wait.until(ec.visibility_of_element_located((By.ID, "documents_info")))
         self.assertInHTML(
             "Showing 1 to 2 of 2 entries",
             self.browser.find_element_by_xpath("//*[@id='documents_info']").text,
+        )
+
+        # Functional uses table
+        self.browser.find_element_by_id("functional-use-tab-header").send_keys("\n")
+        wait.until(ec.visibility_of_element_located((By.ID, "functional-uses_info")))
+        self.assertInHTML(
+            "Showing 1 to 2 of 2 entries",
+            self.browser.find_element_by_xpath("//*[@id='functional-uses_info']").text,
         )
 
     def test_chemical_detail_with_puc(self):
@@ -348,6 +347,20 @@ class TestChemicalDetail(StaticLiveServerTestCase):
                 self.browser.find_element_by_xpath("//*[@id='documents']").text,
             )
 
+        # functional uses table
+        self.browser.find_element_by_id("functional-use-tab-header").send_keys("\n")
+        wait.until(ec.visibility_of_element_located((By.ID, "functional-uses_info")))
+        self.assertInHTML(
+            "Showing 0 to 0 of 0 entries related to PUC Personal care (filtered from 1 total functional uses)",
+            self.browser.find_element_by_xpath("//*[@id='functional-uses_info']").text,
+        )
+        # Make sure the document is also being excluded
+        with self.assertRaises(AssertionError):
+            self.assertInHTML(
+                "Radio Control Vehicle",
+                self.browser.find_element_by_xpath("//*[@id='functional-uses']").text,
+            )
+
         # Clear filter by puc
         self.browser.execute_script("arguments[0].click();", puc_filter)
         time.sleep(1)
@@ -359,7 +372,8 @@ class TestChemicalDetail(StaticLiveServerTestCase):
         self.assertIsNotNone(puc_filter_icon)
 
         # Documents table
-        self.browser.find_element_by_id("document-tab-header").click()
+        self.browser.find_element_by_id("document-tab-header").send_keys("\n")
+        wait.until(ec.visibility_of_element_located((By.ID, "documents_info")))
         self.assertInHTML(
             "Showing 1 to 10 of 19 entries",
             self.browser.find_element_by_xpath("//*[@id='documents_info']").text,
@@ -370,6 +384,13 @@ class TestChemicalDetail(StaticLiveServerTestCase):
         self.assertInHTML(
             "Showing 1 to 6 of 6 entries",
             self.browser.find_element_by_xpath("//*[@id='products_info']").text,
+        )
+        # functional uses table
+        self.browser.find_element_by_id("functional-use-tab-header").send_keys("\n")
+        wait.until(ec.visibility_of_element_located((By.ID, "functional-uses_info")))
+        self.assertInHTML(
+            "Showing 1 to 1 of 1 entries",
+            self.browser.find_element_by_xpath("//*[@id='functional-uses_info']").text,
         )
 
     def test_filter_by_keyword(self):

--- a/dashboard/tests/integration/test_chemical_detail.py
+++ b/dashboard/tests/integration/test_chemical_detail.py
@@ -76,6 +76,7 @@ class TestChemicalDetail(StaticLiveServerTestCase):
         )
 
         # Data Documents
+        self.browser.find_element_by_id("document-tab-header").send_keys("\n")
         wait.until(
             ec.text_to_be_present_in_element(
                 (By.XPATH, "//*[@id='documents_info']"), "Showing 1 to 2 of 2 entries"
@@ -157,6 +158,7 @@ class TestChemicalDetail(StaticLiveServerTestCase):
         chemical = DSSToxLookup.objects.get(sid="DTXSID9020584")
         wait = WebDriverWait(self.browser, 10)
         self.browser.get(self.live_server_url + chemical.get_absolute_url())
+        self.browser.find_element_by_id(("document-tab-header")).click()
         wait.until(
             ec.text_to_be_present_in_element(
                 (By.XPATH, "//*[@id='group_type_dropdown']"), "All"
@@ -306,10 +308,9 @@ class TestChemicalDetail(StaticLiveServerTestCase):
             )
         )
         # filter by PUC
-
+        wait.until(ec.element_to_be_clickable((By.ID, "filter-137")))
         puc_filter = self.browser.find_element_by_id("filter-137")
         puc_filter.click()
-        time.sleep(1)
 
         self.assertEqual(
             puc_filter.get_attribute("data-original-title"), "Clear filter table by PUC"
@@ -334,6 +335,8 @@ class TestChemicalDetail(StaticLiveServerTestCase):
             )
 
         # Documents table
+        self.browser.find_element_by_id("document-tab-header").send_keys("\n")
+        wait.until(ec.visibility_of_element_located((By.ID, "documents_info")))
         self.assertInHTML(
             "Showing 1 to 1 of 1 entries related to PUC Personal care (filtered from 19 total documents)",
             self.browser.find_element_by_xpath("//*[@id='documents_info']").text,
@@ -346,7 +349,7 @@ class TestChemicalDetail(StaticLiveServerTestCase):
             )
 
         # Clear filter by puc
-        puc_filter.click()
+        self.browser.execute_script("arguments[0].click();", puc_filter)
         time.sleep(1)
 
         self.assertEqual(
@@ -356,11 +359,14 @@ class TestChemicalDetail(StaticLiveServerTestCase):
         self.assertIsNotNone(puc_filter_icon)
 
         # Documents table
+        self.browser.find_element_by_id("document-tab-header").click()
         self.assertInHTML(
             "Showing 1 to 10 of 19 entries",
             self.browser.find_element_by_xpath("//*[@id='documents_info']").text,
         )
         # Products table
+        self.browser.find_element_by_id("product-tab-header").send_keys("\n")
+        wait.until(ec.visibility_of_element_located((By.ID, "products_info")))
         self.assertInHTML(
             "Showing 1 to 6 of 6 entries",
             self.browser.find_element_by_xpath("//*[@id='products_info']").text,
@@ -374,7 +380,7 @@ class TestChemicalDetail(StaticLiveServerTestCase):
         chemical = DSSToxLookup.objects.get(sid="DTXSID9020584")
         wait = WebDriverWait(self.browser, 10)
         self.browser.get(self.live_server_url + chemical.get_absolute_url())
-
+        self.browser.find_element_by_id("document-tab-header").send_keys("\n")
         wait.until(
             ec.text_to_be_present_in_element(
                 (By.XPATH, "//*[@id='documents_info']"), "Showing 1 to 8 of 8 entries"

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -314,6 +314,11 @@ urlpatterns = [
         name="chemical_product_ajax_url",
     ),
     path(
+        "chemical_functional_use_json/",
+        views.ChemicalFunctionalUseListJson.as_view(),
+        name="chemical_functional_use_ajax_url",
+    ),
+    path(
         "habitsandpractices/<int:pk>/",
         views.habitsandpractices,
         name="habitsandpractices",

--- a/dashboard/views/chemical.py
+++ b/dashboard/views/chemical.py
@@ -325,7 +325,18 @@ class ChemicalFunctionalUseListJson(BaseDatatableView):
         sid = self.request.GET.get("sid")
         if sid:
             return qs.filter(Q(chem__dsstox__sid=sid)).distinct()
-        return qs.filter()
+        return qs
+
+    def filter_queryset(self, qs):
+        qs = super().filter_queryset(qs)
+        puc = self.request.GET.get("puc")
+        if puc:
+            qs = qs.filter(
+                Q(
+                    chem__extracted_text__data_document__products__product_uber_puc__puc=puc
+                )
+            )
+        return qs
 
     def render_column(self, row, column):
         value = self._render_column(row, column)

--- a/dashboard/views/chemical.py
+++ b/dashboard/views/chemical.py
@@ -14,6 +14,7 @@ from dashboard.models import (
     DuplicateChemicals,
     ProductToPucClassificationMethod,
     ExtractedComposition,
+    FunctionalUse,
 )
 
 
@@ -305,3 +306,39 @@ class ChemicalProductListJson(BaseDatatableView):
         if cm and cm != "all":
             qs = qs.filter(product__product_uber_puc__classification_method__code=cm)
         return qs
+
+
+class ChemicalFunctionalUseListJson(BaseDatatableView):
+    model = FunctionalUse
+    columns = [
+        "chem.extracted_text.data_document.data_group.group_type.title",
+        "chem.extracted_text.data_document.title",
+        "report_funcuse",
+        "category.title",
+    ]
+
+    def get_filter_method(self):
+        return self.FILTER_ICONTAINS
+
+    def get_initial_queryset(self):
+        qs = super().get_initial_queryset()
+        sid = self.request.GET.get("sid")
+        if sid:
+            return qs.filter(Q(chem__dsstox__sid=sid)).distinct()
+        return qs.filter()
+
+    def render_column(self, row, column):
+        value = self._render_column(row, column)
+        if column == "chem.extracted_text.data_document.title":
+            return format_html(
+                '<a href="{}" title="Go to Document detail" target="_blank">{}</a>',
+                row.chem.extracted_text.data_document.get_absolute_url(),
+                value,
+            )
+        # if column == "category.title":
+        #     return format_html(
+        #         '<a href="{}" title="Go to Functional Use Category detail" target="_blank">{}</a>',
+        #         row.category.get_absolute_url(),
+        #         value,
+        #     )
+        return value

--- a/static/js/dashboard/chemical_detail.js
+++ b/static/js/dashboard/chemical_detail.js
@@ -4,6 +4,7 @@ var chemical = $('#chemical'),
     pid = chemical.data('pid'),
     puc_parents = chemical.data('puc-parents'),
     document_table,
+    functional_use_table,
     product_table;
 
 fobc = new nestedBubbleChart(500, 500, false, "/dl_pucs_json/?kind=FO&dtxsid=" + sid, "nestedcircles_FO");
@@ -25,7 +26,14 @@ $( window ).on( "load", function() {
 $(document).ready(function () {
     document_table = build_document_table().on('draw', moveText);
     product_table = build_product_table().on('draw', moveText);
+    functional_use_table = build_functional_use_table();
 
+    $("#document-tab-header").on("click", function() {
+        $('#documents').css('width', '100%');
+    });
+    $("#functional-use-tab-header").on("click", function() {
+        $('#functional-uses').css('width', '100%');
+    });
     //expand accordion to default puc, if one exists
     if (puc_parents.length) {
         $('#accordion-' + puc_parents.join(', #accordion-')).collapse('show');
@@ -126,6 +134,10 @@ function get_documents_url() {
 
 function get_products_url() {
     return '/chemical_product_json/?sid=' + chemical.data('sid') + '&category=' + chemical.data('puc');
+}
+
+function get_functional_uses_url() {
+    return '/chemical_functional_use_json/?sid=' + chemical.data('sid');
 }
 
 function build_document_table() {
@@ -258,8 +270,18 @@ function build_product_table() {
             }
         },
         ajax: get_products_url(),
-        initComplete: function () {
-            $('#products-info-text').text($('#products-info').text())
+        initComplete: function() {
+            $('#products-info-text').text($('#products-info').text());
         }
+    });
+}
+
+function build_functional_use_table() {
+    return $('#functional-uses').DataTable({
+        destroy: true,
+        processing: true,
+        serverSide: true,
+        ordering: true,
+        ajax: get_functional_uses_url()
     });
 }

--- a/templates/chemicals/chemical_detail.html
+++ b/templates/chemicals/chemical_detail.html
@@ -296,7 +296,12 @@
             </div>
 
             <div class="tab-pane container p-0 fade" id="functional-use-table-div">
-                <h4>Functional Uses Associated with "{{ chemical.true_chemname }}"</h4>
+                <h4>Functional Uses Associated with "{{ chemical.true_chemname }}"
+                    <span class="float-right">
+                    <button id="reset-functional-uses" class="btn btn-outline-secondary p-1"
+                            disabled>Show All Functional Uses</button>
+                    </span>
+                </h4>
                 <table class="table table-striped dataTable table-sm" id="functional-uses">
                     <thead>
                     <tr>

--- a/templates/chemicals/chemical_detail.html
+++ b/templates/chemicals/chemical_detail.html
@@ -151,126 +151,167 @@
         </div>
     </div>
 
-    <div class="row mt-4">
-        <div class="tab-content col-12">
-            <h4 class="mt-2 mb-2">Documents Associated with "{{ chemical.true_chemname }}"
-                <span class="float-right">
-                    <button id="reset-documents" class="btn btn-outline-secondary p-1"
-                            disabled>Show All Documents</button>
-                </span>
-            </h4>
-            <table class="table table-striped  dataTable table-sm" id="documents">
-                <thead>
-                <tr>
-                    <th>Document</th>
-                    <th>Data Type</th>
-                </tr>
-                </thead>
-                <tbody></tbody>
-                <tfoot class="m-0">
-                <tr>
-                    <th id="documents-info-text" class="m-0"></th>
-                    <th class="m-0 p-0">
-                        {% if group_types.count > 1 %}
-                            <div class="form-group m-0">
-                                <select class="form-control"
-                                        id="group_type_dropdown"
-                                        title="Filter by Group Type"
-                                        data-placement="left">
-                                    <option value="-1">
-                                        All
-                                    </option>
-                                    {% for gt in group_types %}
-                                        <option value="{{ gt.pk }}">
-                                            {{ gt }}
-                                        </option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                        {% else %}
-                            All 1 GroupType
-                        {% endif %}
-                    </th>
-                </tr>
-                </tfoot>
-            </table>
-        </div>
-    </div>
+    <div class="col-lg-12 mt-4" id="tables">
+        <ul class="row nav nav-pills mb-3">
+            <li class="col-lg-4 nav-item h-nav border rounded p-0">
+                <a class="nav-link text-center active"
+                   data-toggle="pill"
+                   href="#product-table-div"
+                   id="product-tab-header">
+                    <b>Products</b>
+                </a>
+            </li>
+            <li class="col-lg-4 nav-item h-nav border rounded p-0">
+                <a class="nav-link text-center"
+                   data-toggle="pill"
+                   href="#document-table-div"
+                   id="document-tab-header">
+                    <b>Documents</b>
+                </a>
+            </li>
+            <li class="col-lg-4 nav-item h-nav border rounded p-0">
+                <a class="nav-link text-center"
+                   data-toggle="pill"
+                   href="#functional-use-table-div"
+                   id="functional-use-tab-header">
+                    <b>Functional Uses</b>
+                </a>
+            </li>
+        </ul>
 
-
-    <div class="row mt-4">
-        <div class="tab-content col-12">
-            <h4 class="mt-2 mb-2">Products Containing "{{ chemical.true_chemname }}"
-                <span class="float-right">
+        <div class="tab-content">
+            <div class="tab-pane container p-0 active" id="product-table-div">
+                <h4 class="mt-2 mb-2">Products Containing "{{ chemical.true_chemname }}"
+                    <span class="float-right">
                     <button id="reset-products" class="btn btn-outline-secondary p-1"
                             disabled>Show All Products</button>
                 </span>
-            </h4>
-            <table class="table table-striped  dataTable table-sm" id="products">
-                <thead>
-                <tr>
-                    <th>Product</th>
-                    <th>Associated Document</th>
-                    <th>PUC</th>
-                    <th>PUC Kind</th>
-                    <th>Classification Method</th>
-                </tr>
-                </thead>
-                <tbody></tbody>
-
-                <tfoot class="m-0">
-                <tr>
-                    <th id="products-info-text" class="m-0"></th>
-                    <th></th>
-                    <th></th>
-                    <th class="m-0 p-0">
-                        {% if puc_kinds|length > 1 %}
+                </h4>
+                <table class="table table-striped dataTable table-sm" id="products">
+                    <thead>
+                    <tr>
+                        <th>Product</th>
+                        <th>Associated Document</th>
+                        <th>PUC</th>
+                        <th>PUC Kind</th>
+                        <th>Classification Method</th>
+                    </tr>
+                    </thead>
+                    <tbody></tbody>
+                    <tfoot class="m-0">
+                    <tr>
+                        <th id="products-info-text" class="m-0"></th>
+                        <th></th>
+                        <th></th>
+                        <th class="m-0 p-0">
+                            {% if puc_kinds|length > 1 %}
+                                <div class="form-group ml-1">
+                                    <select class="form-control"
+                                            id="puc_kinds_dropdown"
+                                            title="Filter by PUC Kind"
+                                            data-placement="left"
+                                            autocomplete="off">
+                                        <option value="all" selected>
+                                            All
+                                        </option>
+                                        <option value="none">
+                                            No PUC assigned
+                                        </option>
+                                        {% for puc_kind in puc_kinds %}
+                                            <option value="{{ puc_kind.code }}">
+                                                {{ puc_kind.name }}
+                                            </option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            {% else %}
+                                All 1 GroupType
+                            {% endif %}
+                        </th>
+                        <th class="m-0 p-0">
                             <div class="form-group ml-1">
                                 <select class="form-control"
-                                        id="puc_kinds_dropdown"
-                                        title="Filter by PUC Kind"
+                                        id="classification_methods_dropdown"
+                                        title="Filter by Classification Method"
                                         data-placement="left"
                                         autocomplete="off">
                                     <option value="all" selected>
                                         All
                                     </option>
-                                    <option value="none">
-                                        No PUC assigned
-                                    </option>
-                                    {% for puc_kind in puc_kinds %}
-                                        <option value="{{ puc_kind.code }}">
-                                            {{ puc_kind.name }}
+                                    {% for cm in classification_methods %}
+                                        <option value="{{ cm.code }}">
+                                            {{ cm.name }}
                                         </option>
                                     {% endfor %}
                                 </select>
                             </div>
-                        {% else %}
-                            All 1 GroupType
-                        {% endif %}
-                    </th>
-                    <th class="m-0 p-0">
-                        <div class="form-group ml-1">
-                            <select class="form-control"
-                                    id="classification_methods_dropdown"
-                                    title="Filter by Classification Method"
-                                    data-placement="left"
-                                    autocomplete="off">
-                                <option value="all" selected>
-                                    All
-                                </option>
-                                {% for cm in classification_methods %}
-                                    <option value="{{ cm.code }}">
-                                        {{ cm.name }}
-                                    </option>
-                                {% endfor %}
-                            </select>
-                        </div>
-                    </th>
-                </tr>
-                </tfoot>
-            </table>
+                        </th>
+                    </tr>
+                    </tfoot>
+                </table>
+            </div>
+
+            <div class="tab-pane container p-0 fade" id="document-table-div">
+                <h4 class="mt-2 mb-2">Documents Associated with "{{ chemical.true_chemname }}"
+                    <span class="float-right">
+                    <button id="reset-documents" class="btn btn-outline-secondary p-1"
+                            disabled>Show All Documents</button>
+                </span>
+                </h4>
+                <table class="table table-striped dataTable table-sm" id="documents">
+                    <thead>
+                    <tr>
+                        <th>Document</th>
+                        <th>Data Type</th>
+                    </tr>
+                    </thead>
+                    <tbody></tbody>
+                    <tfoot class="m-0">
+                    <tr>
+                        <th id="documents-info-text" class="m-0"></th>
+                        <th class="m-0 p-0">
+                            {% if group_types.count > 1 %}
+                                <div class="form-group m-0">
+                                    <select class="form-control"
+                                            id="group_type_dropdown"
+                                            title="Filter by Group Type"
+                                            data-placement="left">
+                                        <option value="-1">
+                                            All
+                                        </option>
+                                        {% for gt in group_types %}
+                                            <option value="{{ gt.pk }}">
+                                                {{ gt }}
+                                            </option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            {% else %}
+                                All 1 GroupType
+                            {% endif %}
+                        </th>
+                    </tr>
+                    </tfoot>
+                </table>
+            </div>
+
+            <div class="tab-pane container p-0 fade" id="functional-use-table-div">
+                <h4>Functional Uses Associated with "{{ chemical.true_chemname }}"</h4>
+                <table class="table table-striped dataTable table-sm" id="functional-uses">
+                    <thead>
+                    <tr>
+                        <th>Data Type</th>
+                        <th>Document</th>
+                        <th>Reported Functional Use</th>
+                        <th>Harmonized Functional Use</th>
+                    </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
         </div>
     </div>
+
 {% endblock %}
 
 {% block css %}


### PR DESCRIPTION
1. This PR covers ticket #1830, #1827 and #1852
2. Verify functional uses table is added to chemical detail page and can be filtered by PUC.

To Do: add link to functional use category page once #1825 is done.

Sample page:
http://localhost:8000/chemical/DTXSID6026296/