### PR TITLE
1885 QA index page for manually extracted composition docs

### DIFF
--- a/dashboard/forms/forms.py
+++ b/dashboard/forms/forms.py
@@ -262,7 +262,10 @@ class ExtractedTextHPForm(ExtractedTextForm):
 
     def __init__(self, *args, **kwargs):
         super(ExtractedTextHPForm, self).__init__(*args, **kwargs)
-        self.fields["extraction_completed"].widget.attrs.update({"class": "ml-2 align-middle form-control-sm"})
+        self.fields["extraction_completed"].widget.attrs.update(
+            {"class": "ml-2 align-middle form-control-sm"}
+        )
+
 
 class ExtractedTextFUForm(ExtractedTextForm):
     class Meta:

--- a/dashboard/tests/functional/test_extracted_qa.py
+++ b/dashboard/tests/functional/test_extracted_qa.py
@@ -110,7 +110,7 @@ class ExtractedQaTestWithFixtures(TestCase):
         print(ExtractedText.objects.filter(extraction_script=script).count())
 
         response = self.client.get(reverse("qa_manual_composition_index"))
-        self.assertContains(response, "Walmart MSDS", count=6)
+        self.assertContains(response, "Walmart MSDS", count=18)
 
 
         

--- a/dashboard/tests/functional/test_extracted_qa.py
+++ b/dashboard/tests/functional/test_extracted_qa.py
@@ -1,6 +1,5 @@
 from django.test import TestCase, tag
-from django.urls import resolve, reverse
-from lxml import html
+from django.urls import reverse
 
 from dashboard.tests import factories
 from dashboard.tests.loader import load_model_objects, fixtures_standard
@@ -75,7 +74,6 @@ class ExtractedQaTest(TestCase):
         self.assertEqual(5, non_qa)
 
 
-@tag("loader")
 class ExtractedQaTestWithFixtures(TestCase):
 
     fixtures = fixtures_standard
@@ -91,10 +89,10 @@ class ExtractedQaTestWithFixtures(TestCase):
         """
         script = Script.objects.filter(title="Manual (dummy)", script_type="EX").first()
         dgs = DataGroup.objects.filter(group_type__code="CO")
-        
+
         for dg in dgs:
             # add some manually-extracted records in proportion to
-            # the count of records 
+            # the count of records
             doc_count = ExtractedText.objects.filter(
                 data_document__data_group=dg
             ).count()
@@ -109,14 +107,3 @@ class ExtractedQaTestWithFixtures(TestCase):
 
         response = self.client.get(reverse("qa_manual_composition_index"))
         self.assertContains(response, "Walmart MSDS", count=18)
-
-
-        
-
-        
-
-
-        
-
-
-

--- a/dashboard/tests/functional/test_extracted_qa.py
+++ b/dashboard/tests/functional/test_extracted_qa.py
@@ -107,8 +107,6 @@ class ExtractedQaTestWithFixtures(TestCase):
                 data_document__title=f"{dg.name} manually extracted doc",
             )
 
-        print(ExtractedText.objects.filter(extraction_script=script).count())
-
         response = self.client.get(reverse("qa_manual_composition_index"))
         self.assertContains(response, "Walmart MSDS", count=18)
 

--- a/dashboard/tests/functional/test_extracted_qa.py
+++ b/dashboard/tests/functional/test_extracted_qa.py
@@ -1,8 +1,16 @@
 from django.test import TestCase, tag
+from django.urls import resolve, reverse
+from lxml import html
 
 from dashboard.tests import factories
-from dashboard.tests.loader import load_model_objects
-from dashboard.models import QAGroup, ExtractedText, ExtractedFunctionalUse
+from dashboard.tests.loader import load_model_objects, fixtures_standard
+from dashboard.models import (
+    QAGroup,
+    ExtractedText,
+    ExtractedFunctionalUse,
+    Script,
+    DataGroup,
+)
 
 
 @tag("loader")
@@ -65,3 +73,52 @@ class ExtractedQaTest(TestCase):
             extracted_text=extext, qa_flag=False
         ).count()
         self.assertEqual(5, non_qa)
+
+
+@tag("loader")
+class ExtractedQaTestWithFixtures(TestCase):
+
+    fixtures = fixtures_standard
+
+    def setUp(self):
+        self.client.login(username="Karyn", password="specialP@55word")
+
+    def test_qa_manual_composition_index(self):
+        """
+        The yaml fixtures do not include any manually-extracted documents, 
+        so this test uses some factories to generate some for each Composition
+        data group
+        """
+        script = Script.objects.filter(title="Manual (dummy)", script_type="EX").first()
+        dgs = DataGroup.objects.filter(group_type__code="CO")
+        
+        for dg in dgs:
+            # add some manually-extracted records in proportion to
+            # the count of records 
+            doc_count = ExtractedText.objects.filter(
+                data_document__data_group=dg
+            ).count()
+            factory_count = (doc_count // 2) + 1
+
+            extext = factories.ExtractedTextFactory.create_batch(
+                factory_count,
+                data_document__data_group=dg,
+                extraction_script=script,
+                data_document__title=f"{dg.name} manually extracted doc",
+            )
+
+        print(ExtractedText.objects.filter(extraction_script=script).count())
+
+        response = self.client.get(reverse("qa_manual_composition_index"))
+        self.assertContains(response, "Walmart MSDS", count=6)
+
+
+        
+
+        
+
+
+        
+
+
+

--- a/dashboard/tests/functional/test_nav_bar.py
+++ b/dashboard/tests/functional/test_nav_bar.py
@@ -39,6 +39,10 @@ class NavBarTest(TestCase):
         found = resolve("/qa/extractionscript/")
         self.assertEqual(found.func, views.qa_extractionscript_index)
 
+    def test_qa_manually_extracted_composition_link(self):
+        found = resolve("/qa/manualcomposition/")
+        self.assertEqual(found.func, views.qa_manual_composition_index)
+
     def test_get_data_without_auth(self):
         # the Get Data menu item should be available to a user who isn't logged in
         response = self.client.get("/")

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -192,6 +192,11 @@ urlpatterns = [
         name="qa_extractionscript_index",
     ),
     path(
+        "qa/manualcomposition/",
+        views.qa_manual_composition_index,
+        name="qa_manual_composition_index",
+    ),
+    path(
         "qa/extractionscript/<int:pk>/",
         dashboard.views.qa.qa_extraction_script,
         name="qa_extraction_script",

--- a/static/js/dashboard/qa_manual_composition_index.js
+++ b/static/js/dashboard/qa_manual_composition_index.js
@@ -1,0 +1,14 @@
+$(document).ready(function () {
+  var table = $('#data_group_table').DataTable({
+  // "lengthMenu": [ 10, 25, 50, 75, 100 ], // change number of records shown
+  "columnDefs": [
+      {
+          "targets": [1, 4, 5],
+          "orderable": false
+      }
+  ],
+  dom:"<'row'<'col-md-4 form-inline'l><'col-md-4 form-inline'f>>" +
+      "<'row'<'col-sm-12 text-center'tr>>" +
+      "<'row'<'col-sm-5'i><'col-sm-7'p>>" // order the control divs
+  });
+});

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -190,6 +190,10 @@
                             Composition - Ext. Script
                         </a>
                         <a class="dropdown-item"
+                            href="{% url 'qa_manual_composition_index' %}">
+                            Composition - Manual
+                        </a>
+                        <a class="dropdown-item"
                            href="{% url 'qa_extractionscript_index' %}?group_type=FU">
                             Functional Use - Ext. Script
                         </a>

--- a/templates/qa/qa_manual_composition_index.html
+++ b/templates/qa/qa_manual_composition_index.html
@@ -7,7 +7,7 @@
 <h1 class="col-sm-12"><span class="fa fa-check-square" title="factotum"></span>
 QA Manually Extracted Composition Documents</h1>
 <br>
-<table class="table table-striped table-bordered dataTable no-footer" id='chemical_presence_table'>
+<table class="table table-striped table-bordered dataTable no-footer" id='data_group_table'>
     <thead class="table-primary">
         <tr>
         <th>Data Group</th>
@@ -31,8 +31,8 @@ QA Manually Extracted Composition Documents</h1>
         {% widthratio datagroup.approved_count datagroup.datadocument_count 100 as pct_complete %}
         <td>{{  pct_complete|default:"0" }}%</td>
         <td>
-            <a href="{% url 'qa_chemical_presence_summary' datagroup.id %}"
-               title="Link to {{ datagroup.name }} Summary" id="{{datagroup.id}}">
+            <a href="/"
+               title="Link to {{ datagroup.name }} Summary" id="a-ummary-link-{{datagroup.id}}">
                 <span class="fa fa-tasks"></span>
             </a>
         </td>
@@ -42,7 +42,7 @@ QA Manually Extracted Composition Documents</h1>
               <a class="btn btn-light btn-sm" disabled role="button" title="QA Complete">QA Complete</a>
             {% else %}
               <a class="btn btn-info btn-sm" role="button" title="QA on {{ datagroup.name }}"
-               href='{% url "qa_chemical_presence_group" datagroup.id %}'> View Chemical Presence Lists
+               href='/'> View Manually Extracted Composition Records
               </a>
             {% endif %}
         {% else %}

--- a/templates/qa/qa_manual_composition_index.html
+++ b/templates/qa/qa_manual_composition_index.html
@@ -56,5 +56,5 @@ QA Manually Extracted Composition Documents</h1>
 {% endblock %}
 
 {% block js %}
-    <script src="{% static 'js/dashboard/qa_chemical_presence_index.js' %}"></script>
+    <script src="{% static 'js/dashboard/qa_manual_composition_index.js' %}"></script>
 {% endblock %}

--- a/templates/qa/qa_manual_composition_index.html
+++ b/templates/qa/qa_manual_composition_index.html
@@ -1,0 +1,60 @@
+{% extends 'core/base.html' %}
+{% load staticfiles %}
+{% load humanize %}
+{% block title %}QA Manually Extracted Composition Documentss{% endblock %}
+
+{% block content %}
+<h1 class="col-sm-12"><span class="fa fa-check-square" title="factotum"></span>
+QA Manually Extracted Composition Documents</h1>
+<br>
+<table class="table table-striped table-bordered dataTable no-footer" id='chemical_presence_table'>
+    <thead class="table-primary">
+        <tr>
+        <th>Data Group</th>
+        <th>URL</th>
+        <th>Document Count</th>
+        <th>Percent QA Checked</th>
+        <th>QA Summary</th>
+        <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for datagroup in datagroups %}
+      <tr>
+        <td><a href="{% url 'data_group_detail' datagroup.id %}" id="{{datagroup.id}}">{{ datagroup.name }}</a></td>
+        <td>
+            {% if datagroup.url %}
+                <a href="{{ datagroup.url }}" target="_blank"><span class="fa fa-external-link-alt"></span></a>
+            {% endif %}
+        </td>
+        <td>{{ datagroup.datadocument_count }}</td>
+        {% widthratio datagroup.approved_count datagroup.datadocument_count 100 as pct_complete %}
+        <td>{{  pct_complete|default:"0" }}%</td>
+        <td>
+            <a href="{% url 'qa_chemical_presence_summary' datagroup.id %}"
+               title="Link to {{ datagroup.name }} Summary" id="{{datagroup.id}}">
+                <span class="fa fa-tasks"></span>
+            </a>
+        </td>
+        <td>
+        {% if datagroup.datadocument_count > 0 %}
+            {% if pct_complete == "100" %}
+              <a class="btn btn-light btn-sm" disabled role="button" title="QA Complete">QA Complete</a>
+            {% else %}
+              <a class="btn btn-info btn-sm" role="button" title="QA on {{ datagroup.name }}"
+               href='{% url "qa_chemical_presence_group" datagroup.id %}'> View Chemical Presence Lists
+              </a>
+            {% endif %}
+        {% else %}
+            <i>No DataDocuments exist in this Datagroup</i>
+        {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}
+
+{% block js %}
+    <script src="{% static 'js/dashboard/qa_chemical_presence_index.js' %}"></script>
+{% endblock %}


### PR DESCRIPTION
closes: #1885 

The seed data does not include manually-extracted composition records, so I used a factory to create them in my test. If you want to add them to your local dev environment, this code from the test should work in the shell:

```{python}
from dashboard.tests import factories

from dashboard.models import (
    ExtractedText,
    Script,
    DataGroup,
)
script = Script.objects.filter(title="Manual (dummy)", script_type="EX").first()
dgs = DataGroup.objects.filter(group_type__code="CO")

for dg in dgs:
    # add some manually-extracted records in proportion to
    # the count of records
    doc_count = ExtractedText.objects.filter(
        data_document__data_group=dg
    ).count()
    factory_count = (doc_count // 2) + 1

    extext = factories.ExtractedTextFactory.create_batch(
        factory_count,
        data_document__data_group=dg,
        extraction_script=script,
        data_document__title=f"{dg.name} manually extracted doc",
    )
```