### PR TITLE
Hotfix Provisional DTXSID Assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ target/
 # celery beat schedule file
 celerybeat-schedule
 celerybeat-schedule.*
+celerybeat.pid
 
 # SageMath parsed files
 *.sage.py

--- a/dashboard/migrations/0191_drop_auditlog_extracted_text_fk.py
+++ b/dashboard/migrations/0191_drop_auditlog_extracted_text_fk.py
@@ -24,6 +24,8 @@ class Migration(migrations.Migration):
     dependencies = [("dashboard", "0190_rawchem_provisional")]
 
     operations = [
+        # Removes a foreign key constraint specifically added in 0174,
+        # This returns this row to reflecting the model's definition.
         migrations.RunPython(
             code=drop_audit_log_extracted_text_fk,
             reverse_code=empty_reverse_function,

--- a/dashboard/migrations/0191_drop_auditlog_extracted_text_fk.py
+++ b/dashboard/migrations/0191_drop_auditlog_extracted_text_fk.py
@@ -1,0 +1,32 @@
+from django.db import migrations, connection
+
+
+def drop_audit_log_extracted_text_fk(apps, schema_editor):
+    with connection.cursor() as c:
+        try:
+            c.execute(
+                """
+                alter table dashboard_auditlog
+                drop foreign key dashboard_auditlog_extracted_text_id_bf4860ab_fk_dashboard
+                """
+            )
+        except Exception as e:
+            print(e)
+
+
+def empty_reverse_function(apps, schema_editor):
+    # The reverse function is not required
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("dashboard", "0190_rawchem_provisional")]
+
+    operations = [
+        migrations.RunPython(
+            code=drop_audit_log_extracted_text_fk,
+            reverse_code=empty_reverse_function,
+            atomic=True,
+        )
+    ]

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -46,9 +46,13 @@ def provisional_sid_assignment():
         raw_cas = provision_kwargs.get("raw_cas", "")
         logger.debug(f"Provisioning Name {raw_chem_name} and CAS {raw_cas}")
 
-        provision_dsstox_id = RawChem.objects.filter(
-            raw_chem_name=raw_chem_name, raw_cas=raw_cas, dsstox__isnull=False
-        ).values_list("dsstox_id", flat=True)
+        provision_dsstox_id = (
+            RawChem.objects.filter(
+                raw_chem_name=raw_chem_name, raw_cas=raw_cas, dsstox__isnull=False
+            )
+            .distinct()
+            .values_list("dsstox_id", flat=True)
+        )
 
         if len(provision_dsstox_id) == 1:
             provision_dsstox_id = provision_dsstox_id.first()

--- a/dashboard/tests/functional/test_auditlog.py
+++ b/dashboard/tests/functional/test_auditlog.py
@@ -395,17 +395,6 @@ class AuditLogTest(TempFileMixin, TransactionTestCase):
             self.assertIsNotNone(log.user_id)
             self.assertEquals("D", log.action, "Should be delete action")
 
-        # delete data document should cascade delete all auditlogs
-        dd = DataDocument.objects.get(pk=dd_id)
-        auditlogs = AuditLog.objects.filter(extracted_text_id=dd_id)
-
-        self.assertIsNotNone(dd)
-        self.assertTrue(auditlogs.count() > 0)
-
-        dd.delete()
-        auditlogs = AuditLog.objects.filter(extracted_text_id=dd_id)
-        self.assertTrue(auditlogs.count() == 0)
-
     def test_functional_use_audit_logs(self):
         ext = ExtractedText.objects.create(
             data_document=DataDocument.objects.first(),


### PR DESCRIPTION
There was a bug where if more than one dsstox id was returned found, the record would not be provisioned.
A `.distinct()` was added to change this to requiring more than one different dsstox id.

Also dropped the auditlog extracted_text_id foreign key constraint. There are rows in production rawchem table whose extracted_text_id that does not exists in extractedtext table, which is wrong. This caused error throw when set the provisional sid. Drop the constraint is auditlog is fine as this is audit trail anyway. But how the production database get into this state is still unknown/unresolved.