### PR TITLE
1937: remove provisional flag with curation break

### DIFF
--- a/dashboard/fixtures/07d_rawchem.yaml
+++ b/dashboard/fixtures/07d_rawchem.yaml
@@ -320,6 +320,7 @@
     dsstox: 9
     component: ''
     chem_detected_flag: null
+    provisional: True
 - model: dashboard.rawchem
   pk: 25
   fields:

--- a/dashboard/forms/forms.py
+++ b/dashboard/forms/forms.py
@@ -701,5 +701,5 @@ class RemoveCuratedChemicalLinkageForm(forms.Form):
         sid = self.cleaned_data["sid"]
         RawChem.objects.filter(
             raw_chem_name=raw_chem_name, raw_cas=raw_cas, dsstox__sid=sid
-        ).update(dsstox_id=None)
+        ).update(dsstox_id=None, provisional=False)
         return f"Raw chemical {raw_chem_name}/{raw_cas} linkages to curated chemical {sid} have been removed"

--- a/dashboard/tests/integration/test_curated_chemical_removal.py
+++ b/dashboard/tests/integration/test_curated_chemical_removal.py
@@ -110,10 +110,22 @@ class TestCuratedChemicalRemoval(StaticLiveServerTestCase):
                 "Raw chemical Chlorine/7782-50-5 linkages to curated chemical DTXSID1020273 have been removed",
             )
         )
-        raw_chem = RawChem.objects.filter(
+        rc_uncurated = RawChem.objects.filter(
             raw_chem_name="chlorine", raw_cas="7782-50-5"
-        ).first()
+        )
+        raw_chem = rc_uncurated.first()
         self.assertEqual(raw_chem.dsstox, None)
+
+        # Removing the dsstox reference should also cause the
+        # `provisional` attribute to be nulled out
+        for rc in rc_uncurated:
+            print(f"{rc.id}: provisional is {rc.provisional}, dsstox is {rc.dsstox}")
+
+        rc_provisional = rc_uncurated.filter(provisional=True)
+        self.assertIsNone(
+            rc_provisional.first(),
+            "All of the now-uncurated records should have provisional=False",
+        )
 
         audit_entry = AuditLog.objects.first()
         self.assertIsNotNone(audit_entry)


### PR DESCRIPTION
Closes: #1937 

Not much was needed here. The `provisional` flag is now set to `False` when the `RemoveCuratedChemicalLinkageForm` on the `/curated_chemical_removal/` page does its thing. 

Note that this form's `save(self)` method is the only place the `provisional` field is synced with curation removal. If some other function uses the ORM or a database query to uncurate a `RawChem` record by setting the `dsstox` value to `None`, the flag will not be reset.