### PR TITLE
1941: remove empty Reported Functional Uses from curation page

### DIFF
--- a/dashboard/tests/functional/test_functional_use_curation.py
+++ b/dashboard/tests/functional/test_functional_use_curation.py
@@ -2,7 +2,11 @@ from django.test import TestCase, override_settings
 from django.test.client import Client
 from django.urls import reverse
 
-from dashboard.models import FunctionalUse, FunctionalUseCategory
+from dashboard.models import (
+    FunctionalUse,
+    FunctionalUseCategory,
+    FunctionalUseToRawChem,
+)
 from dashboard.tests.loader import fixtures_standard
 
 
@@ -49,3 +53,12 @@ class TestFunctionalUseCuration(TestCase):
         self.assertEqual(
             len(combinations), 16, "There should be 16 combinations after the edit"
         )
+
+    def test_functional_use_cleanup(self):
+        # cut linkage and invoke cleanup
+        FunctionalUseToRawChem.objects.all().delete()
+        self.client.post(reverse("functional_use_cleanup"))
+
+        response = self.client.get(reverse("functional_use_curation"))
+        combinations = response.context["combinations"]
+        self.assertEqual(len(combinations), 0, f"There should be 0 combinations")

--- a/dashboard/tests/integration/test_chemical_detail.py
+++ b/dashboard/tests/integration/test_chemical_detail.py
@@ -408,6 +408,8 @@ class TestChemicalDetail(StaticLiveServerTestCase):
                 (By.XPATH, "//*[@id='documents_info']"), "Showing 1 to 8 of 8 entries"
             )
         )
+        # Click table heading
+        self.browser.find_element_by_id("lpkHeading").click()
         # filter by keyword
         keyword_filter = self.browser.find_element_by_id("keywords-1")
         keyword_filter.click()

--- a/dashboard/tests/integration/test_functional_use_curation.py
+++ b/dashboard/tests/integration/test_functional_use_curation.py
@@ -125,3 +125,32 @@ class TestFunctionalUseCuration(StaticLiveServerTestCase):
             reverse("data_document", kwargs={"pk": self.excomp.extracted_text.pk}),
             table.get_attribute("innerHTML"),
         )
+
+    def test_functional_use_cleanup(self):
+        self.browser.get(self.live_server_url + reverse("functional_use_curation"))
+
+        # Check reported functional use is on the response
+        self.wait.until(
+            ec.text_to_be_present_in_element(
+                (By.ID, "dataGrid"), f"{self.functional_use.report_funcuse}"
+            )
+        )
+
+        # delete chemical
+        self.excomp.delete()
+
+        # invoke cleanup button
+        remove_button = self.browser.find_element_by_id("delete-fu-btn")
+        remove_button.click()
+        self.wait.until(ec.element_to_be_clickable((By.ID, "remove-fu-confirm-btn")))
+        self.browser.find_element_by_id("remove-fu-confirm-btn").click()
+        self.wait.until(
+            ec.text_to_be_present_in_element(
+                (By.CLASS_NAME, "alert-success"),
+                "1 reported functional use(s) successfully removed",
+            )
+        )
+        self.assertIn(
+            "No Rows To Show",
+            self.browser.find_element_by_id("dataGrid").get_attribute("innerHTML"),
+        )

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -171,6 +171,11 @@ urlpatterns = [
         name="category_assignment",
     ),
     path(
+        "functional_use_cleanup/",
+        views.functional_use_cleanup,
+        name="functional_use_cleanup",
+    ),
+    path(
         "functional_use_curation/",
         views.functional_use_curation,
         name="functional_use_curation",

--- a/dashboard/views/functional_use_curation.py
+++ b/dashboard/views/functional_use_curation.py
@@ -1,5 +1,6 @@
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.shortcuts import render, reverse, get_object_or_404
+from django.shortcuts import render, reverse, get_object_or_404, redirect
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count, F
 from dashboard.models import FunctionalUse, FunctionalUseCategory
@@ -10,6 +11,27 @@ from django.views.generic import TemplateView
 from django_datatables_view.base_datatable_view import BaseDatatableView
 
 from dashboard.models import FunctionalUse, RawChem
+
+
+@login_required()
+def functional_use_cleanup(request):
+    if request.method == "POST":
+        # remove all reported functional uses that are not associated with chemicals
+        result = (
+            FunctionalUse.objects.annotate(chem_count=Count("chemicals"))
+            .filter(chem_count=0)
+            .delete()
+        )
+        removed_count = result[0]
+        if removed_count > 0:
+            messages.success(
+                request,
+                f"{removed_count} reported functional use(s) successfully removed",
+            )
+        else:
+            messages.warning(request, "No reported functional use removed")
+
+    return redirect("functional_use_curation")
 
 
 @login_required()

--- a/static/js/dashboard/functional_use_curation.js
+++ b/static/js/dashboard/functional_use_curation.js
@@ -129,8 +129,8 @@ var columnDefs = [
         cellRenderer: CategoryCellRenderer
     },
     {
-        headerName: "Chemical Count", field: "fu_count", cellRenderer: params => {
-            return `<a href="/functional_use_curation/${params.data.pk}/"> ${params.data.fu_count} </a>`
+        headerName: "Chemical Entries", field: "fu_count", cellRenderer: params => {
+            return `<a href="/functional_use_curation/${params.data.pk}/" target="_blank"> ${params.data.fu_count} </a>`
         }
     },
 ];

--- a/templates/functional_use_curation/functional_use_curation.html
+++ b/templates/functional_use_curation/functional_use_curation.html
@@ -6,13 +6,22 @@
     <h1>
         <span>Functional Use Curation</span>
     </h1>
+
+    <div class="btn-group pt-2 pb-4">
+        <button type="button" data-toggle="modal" data-target="#confirm-modal" id="delete-fu-btn"
+                class="btn btn-warning">Remove reported functional uses not associated with chemicals
+        </button>
+    </div>
+
     <div class="row pt-2 pb-4">
         <div class="col-12">Select a Harmonized Category cell to update. Follow the Chemical Count link to view associated chemicals.</div>
     </div>
     <div class="row">
         <div class="col-4"><input type="text" id="filter-text-box" placeholder="Search..."></div>
         <div class="col-4"><span id="results" class="btn-primary m-2"></span></div>
-        <div class="col-4 text-right"><button id="filter-reset-button" class="btn btn-primary btn-sm">Reset Filters</button></div>
+        <div class="col-4 text-right">
+            <button id="filter-reset-button" class="btn btn-primary btn-sm">Reset Filters</button>
+        </div>
     </div>
     <div id="dataGrid" class="ag-theme-balham fixed-height-grid"></div>
     <div>
@@ -24,6 +33,46 @@
             <option value="100">100</option>
             <option value="All">Show All</option>
         </select>
+    </div>
+
+    <div class="modal fade"
+         id="confirm-modal"
+         tabindex="-1" role="dialog"
+         aria-labelledby="modalLabel"
+         aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 id="modalLabel">Remove Reported Functional Uses</h5>
+                    <button type="button"
+                            class="close"
+                            data-dismiss="modal"
+                            aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body" id="confirm-message">
+                    Are you sure to remove all reported functional uses that are not associated with any chemicals?
+                </div>
+                <div class="modal-footer">
+                    <button id="toggle-flags-cancel-btn"
+                            type="button"
+                            class="btn btn-secondary"
+                            data-dismiss="modal">
+                        No
+                    </button>
+                    <form action='{% url 'functional_use_cleanup' %}' method="post"
+                          id="remove-fu-form">
+                        {% csrf_token %}
+                        <button id="remove-fu-confirm-btn"
+                                type="submit"
+                                class="btn btn-primary">
+                            Yes
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
     </div>
 {% endblock %}
 


### PR DESCRIPTION
Closes #1941 

Added button to remove reported functional uses with no chemical on /functional_use_curation/ page.