### PR TITLE
2042: update container names

### DIFF
--- a/docker/docker-compose.override.yaml
+++ b/docker/docker-compose.override.yaml
@@ -65,7 +65,7 @@ services:
     depends_on:
       - elasticsearch
 
-  factotum-nginx:
+  nginx:
     image: nginx:1-alpine
     restart: unless-stopped
     ports:

--- a/template.env
+++ b/template.env
@@ -1,3 +1,4 @@
+COMPOSE_PROJECT_NAME=factotum
 COMPOSE_PATH_SEPARATOR=;
 # production environment:
 #    COMPOSE_FILE=docker/docker-compose.yaml;docker/docker-compose.override.yaml


### PR DESCRIPTION
Closes #2042 

Add `COMPOSE_PROJECT_NAME=factotum` to .env will make all services has `factotum_` prefix.

The container name for pretty self-explained:
1. factotum_factotum: the factotum web application
2. factotum_factotum-ws: the factotum web services API application
3. factotum_nginx: the nginx proxy to serve factotum and factotum-ws
4. factotum_celery: the celery task worker service
5. factotum_celery-beat: the celery beat service for scheduled tasks
6. factotum_redis: the redis host used by django and celery
7. factotum_elasticsearch: the elastic search host
8. factotum_logstash: the logstash host to feed data to elastic
