### PR TITLE
2055 ongoing: disable bulk download

### DIFF
--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -23,11 +23,11 @@ def setup_periodic_tasks(sender, **kwargs):
         provisional_sid_assignment.s(),
         name="provisional_sid_assignment",
     )
-    sender.add_periodic_task(
-        crontab(*settings.GENERATE_BULK_DOWNLOAD_SCHEDULE.split(" ")),
-        generate_bulk_download_file.s(),
-        name="generate_bulk_download_csv",
-    )
+    # sender.add_periodic_task(
+    #     crontab(*settings.GENERATE_BULK_DOWNLOAD_SCHEDULE.split(" ")),
+    #     generate_bulk_download_file.s(),
+    #     name="generate_bulk_download_csv",
+    # )
 
 
 @app.task


### PR DESCRIPTION
We have decided to disable the bulk download feature while we ask the DB admin to troubleshoot the possible MySQL error.

To test any configuration changes, use this code inside a shell launched with `python manage.py shell`:
```
from dashboard.tasks import generate_bulk_download_file
generate_bulk_download_file.apply()
```