### PR TITLE
2118 Add PUC ID to download

### DIFF
--- a/dashboard/tests/functional/test_auditlog.py
+++ b/dashboard/tests/functional/test_auditlog.py
@@ -2,7 +2,7 @@ import crum
 import io
 from urllib import parse
 
-from django.test import RequestFactory, Client
+from django.test import RequestFactory, Client, tag
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import InMemoryUploadedFile
 
@@ -42,6 +42,7 @@ def make_upload_csv(filename):
     return in_mem_sample_csv
 
 
+@tag("fails_in_suite")
 class AuditLogTest(TempFileMixin, TransactionTestCase):
     fixtures = [
         "00_superuser.yaml",

--- a/dashboard/tests/functional/test_dashboard.py
+++ b/dashboard/tests/functional/test_dashboard.py
@@ -92,22 +92,23 @@ class DashboardTest(TestCase):
         self.assertEqual(
             csv_lines[0],
             (
-                "General category,Product family,Product type,"
+                "ID,General category,Product family,Product type,"
                 "Allowed attributes,Assumed attributes,Description,PUC type,PUC level,Product count,Cumulative product count"
             ),
         )
         # check the PUC from loader
         row1 = csv_lines[1].split(",")
-        self.assertEqual(len(row1), 10)
-        self.assertEqual(row1[0], "Test General Category")
-        self.assertEqual(row1[1], "Test Product Family")
-        self.assertEqual(row1[2], "Test Product Type")
-        self.assertEqual(row1[3], "aerosol; foamspray")
-        self.assertEqual(row1[4], "foamspray")
-        self.assertEqual(row1[5], "Test Product Description")
-        self.assertEqual(row1[6], "FO")
-        self.assertEqual(row1[7], "3")
-        self.assertEqual(row1[8], "0")
+        self.assertEqual(len(row1), 11)
+        self.assertEqual(row1[0], str(puc.pk))
+        self.assertEqual(row1[1], "Test General Category")
+        self.assertEqual(row1[2], "Test Product Family")
+        self.assertEqual(row1[3], "Test Product Type")
+        self.assertEqual(row1[4], "aerosol; foamspray")
+        self.assertEqual(row1[5], "foamspray")
+        self.assertEqual(row1[6], "Test Product Description")
+        self.assertEqual(row1[7], "FO")
+        self.assertEqual(row1[8], "3")
+        self.assertEqual(row1[9], "0")
 
     def test_collapsible_tree_PUCs(self):
         # Keys that must be present at every level

--- a/dashboard/tests/functional/test_datadocument_detail.py
+++ b/dashboard/tests/functional/test_datadocument_detail.py
@@ -1,7 +1,7 @@
 import os
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.test import TransactionTestCase, TestCase, override_settings
+from django.test import TransactionTestCase, TestCase, override_settings, tag
 from django.urls import reverse
 from lxml import html
 from dashboard.tests.loader import load_model_objects
@@ -29,6 +29,7 @@ from dashboard.tests.loader import fixtures_standard, datadocument_models
 from dashboard.utils import get_extracted_models
 
 
+@tag("fails_in_suite")
 @override_settings(ALLOWED_HOSTS=["testserver"])
 class DataDocumentDetailTest(TransactionTestCase):
     fixtures = fixtures_standard

--- a/dashboard/tests/functional/test_extracted_text_upload.py
+++ b/dashboard/tests/functional/test_extracted_text_upload.py
@@ -2,7 +2,7 @@ import io
 import bs4
 from urllib import parse
 
-from django.test import RequestFactory, Client
+from django.test import RequestFactory, Client, tag
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.files import File
 
@@ -42,6 +42,7 @@ def make_upload_csv(filename):
     return in_mem_sample_csv
 
 
+@tag("fails_in_suite")
 class UploadExtractedFileTest(TempFileMixin, TransactionTestCase):
     fixtures = [
         "00_superuser.yaml",

--- a/dashboard/tests/functional/test_product_csv_upload.py
+++ b/dashboard/tests/functional/test_product_csv_upload.py
@@ -3,7 +3,7 @@ import re
 from datetime import datetime
 import glob
 
-from django.test import RequestFactory, TestCase, Client
+from django.test import RequestFactory, TestCase, Client, tag
 from django.contrib.auth.models import User
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -130,6 +130,7 @@ class UploadProductTest(TempFileMixin, TestCase):
                     f"Product field {field.name} is not being set by csv",
                 )
 
+    @tag("fails_in_suite")
     def test_valid_product_data_upload_with_image(self):
         sample_csv = (
             "data_document_id,data_document_filename,title,upc,url,brand_name,size,color,item_id,parent_item_id,short_description,long_description,epa_reg_number,thumb_image,medium_image,large_image,model_number,manufacturer,image_name\n"
@@ -214,6 +215,7 @@ class UploadProductTest(TempFileMixin, TestCase):
             f"Please correct or remove their image_names and retry the upload: {self.docs[0].pk}, {self.docs[1].pk}",
         )
 
+    @tag("fails_in_suite")
     def test_image_file_too_large_error(self):
         """
         Rows with images that arent in the uploaded directory should be rejected
@@ -244,6 +246,7 @@ class UploadProductTest(TempFileMixin, TestCase):
             post_pdcount, pre_pdcount, "No rows should have been processed"
         )
 
+    @tag("fails_in_suite")
     def test_image_directory_too_large_error(self):
         """
         Rows with images that arent in the uploaded directory should be rejected
@@ -267,6 +270,7 @@ class UploadProductTest(TempFileMixin, TestCase):
             post_pdcount, pre_pdcount, "No rows should have been processed"
         )
 
+    @tag("fails_in_suite")
     def test_image_directory_exceeds_count_error(self):
         """
         Rows with images that arent in the uploaded directory should be rejected

--- a/dashboard/tests/functional/test_product_detail.py
+++ b/dashboard/tests/functional/test_product_detail.py
@@ -213,6 +213,7 @@ class TestProductDetail(TransactionTestCase):
         self.assertContains(response, "<dt>PUC Kind:</dt>")
         self.assertContains(response, Product.objects.get(pk=11).uber_puc.kind)
 
+    @tag("fails_in_suite")
     def test_image_upload(self):
         product_pk = 878
         product = Product.objects.get(pk=product_pk)

--- a/dashboard/views/ajax.py
+++ b/dashboard/views/ajax.py
@@ -163,9 +163,9 @@ class DocumentListJson(FilterDatatableView):
         return qs
 
     def render_column(self, row, column):
-        
+
         if column == "extractedtext.doc_date":
-            if hasattr(row, 'extractedtext'):
+            if hasattr(row, "extractedtext"):
                 value = row.extractedtext.doc_date
             else:
                 value = None

--- a/dashboard/views/dashboard.py
+++ b/dashboard/views/dashboard.py
@@ -164,6 +164,7 @@ def download_PUCs(request):
     )
     writer = csv.writer(response)
     cols = [
+        "ID",
         "General category",
         "Product family",
         "Product type",
@@ -178,6 +179,7 @@ def download_PUCs(request):
     writer.writerow(cols)
     for puc in pucs:
         row = [
+            puc.pk,
             puc.gen_cat,
             puc.prod_fam,
             puc.prod_type,


### PR DESCRIPTION
Closes: #2118 

Simple ticket - this just adds the ID column to the PUC download. I have also added a tag to several tests that fail when the entire suite is run but pass when they are run in isolation. 
```
python manage.py test dashboard.tests.functional
```
Fails.
```
python manage.py test dashboard.tests.functional --exclude-tag=fails_in_suite
python manage.py test dashboard.tests.functional --tag=fails_in_suite
```
Works